### PR TITLE
getPolyfillString without check for unsupported ua

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,20 +205,14 @@ const PolyfillLibrary = class PolyfillLibrary {
 	 */
 	getPolyfillString(opts) {
 		const options = this.getOptions(opts);
-		const ua = new UA(options.uaString);
 		const lf = options.minify ? "" : "\n";
 		const allWarnText =
 			"Using the `all` alias with polyfill.io is a very bad idea. In a future version of the service, `all` will deliver the same behaviour as `default`, so we recommend using `default` instead.";
 		const output = mergeStream();
 		const explainerComment = [];
-		// Check UA and turn requested features into a list of polyfills
-		const unsupportedUA =
-			(!ua.meetsBaseline() || ua.isUnknown()) && options.unknown !== "polyfill";
 
-		Promise.resolve(unsupportedUA ? {} : this.getPolyfills(options))
-
-			// Build a polyfill bundle of polyfill sources sorted in dependency order
-			.then(targetedFeatures => {
+		// Build a polyfill bundle of polyfill sources sorted in dependency order
+		this.getPolyfills(options).then(targetedFeatures => {
 				const warnings = { unknown: [] };
 				const graph = tsort();
 


### PR DESCRIPTION
When given an unsupported (possibly empty) UA string together with `unknown: 'ignore'` then `getPolyfills` returns only features that have the `always` flag set.

Example:
```
polyfillLibrary.getPolyfills({
    features: {
        Promise: {flags: ['always']},
        JSON: {flags: []}
    },
    unknown: 'ignore'
}).then(console.log)
```
logs: `{ Promise: { flags: Set { 'always' } } }`


But `getPolyfillString` (called with the same options) returns no polyfills. The `always` flag is not respected.

With my little change, `getPolyfillString` returns the same polyfills as `getPolyfills`.