### PR TITLE
Add dotenv dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "yaku": "0.18.6"
   },
   "devDependencies": {
+    "dotenv": "^6.2.0",
     "eslint": "^4.9.0",
     "execa": "^1.0.0",
     "globby": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,6 +1427,11 @@ dom-serialize@^2.2.0:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
+dotenv@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
+  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
It's required in the `updatebrowserstacklist` test

<img width="629" alt="a screenshot of dotenv being used in the updatebrowserstacklist test" src="https://user-images.githubusercontent.com/178266/51268604-72127580-19b8-11e9-8a7e-d74ad05179fc.png">
