### PR TITLE
Use contributing guide url for contributing guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ npm run test-polyfills -- --feature=Array.from --browserstack # Run the tests fo
 Polyfill-library is [MIT licensed][license].
 
 [contributing-guide]: https://github.com/Financial-Times/polyfill-library/blob/master/.github/contributing.md
-[license]: .././LICENSE.md
+[license]: https://github.com/Financial-Times/polyfill-library/blob/master/LICENSE.md
 [license-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [pull-requests-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npm run test-polyfills -- --feature=Array.from --browserstack # Run the tests fo
 
 Polyfill-library is [MIT licensed][license].
 
-[contributing-guide]: https://example.com
+[contributing-guide]: https://github.com/Financial-Times/polyfill-library/blob/master/.github/contributing.md
 [license]: .././LICENSE.md
 [license-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [pull-requests-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg


### PR DESCRIPTION
I'm not sure if I'm allowed to contribute this, because <kbd>PRs welcome</kbd> linked me to [example.com](https://example.com)
