### PR TITLE
Add Array.prototype.flatMap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,8 @@ jobs:
           --browserstack
       - run: npm run test-polyfills -- --features=String.prototype.trim
           --browserstack
+      - run: npm run test-polyfills -- --features=Array.prototype.flatMap
+          --browserstack
 workflows:
   test:
     jobs:

--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ polyfills/__dist/**
 polyfills/_ArrayIterator/polyfill.js
 polyfills/_TypedArray/polyfill.js
 polyfills/Array/of/polyfill.js
+polyfills/Array/prototype/flatMap/polyfill.js
 polyfills/Array/prototype/values/polyfill.js
 polyfills/atob/polyfill.js
 polyfills/AudioContext/polyfill.js

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ polyfills/_TypedArray/polyfill.js
 polyfills/atob/polyfill.js
 polyfills/fetch/polyfill.js
 .nyc_output/
+polyfills/Array/prototype/flatMap/polyfill.js

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@financial-times/polyfill-useragent-normaliser": "1.0.6",
     "Base64": "^1.0.0",
     "array.of": "^0.1.1",
+    "array.prototype.flatmap": "^1.2.1",
     "audio-context-polyfill": "^1.0.0",
     "babel-core": "^6.23.1",
     "babel-preset-es2015": "^6.1.18",

--- a/polyfills/Array/prototype/flatMap/config.json
+++ b/polyfills/Array/prototype/flatMap/config.json
@@ -1,0 +1,32 @@
+{
+    "aliases": [
+        "es6",
+        "es2015",
+        "modernizr:es6array"
+    ],
+    "browsers": {
+        "bb": "*",
+        "chrome": "<68",
+        "edge": "*",
+        "edge_mob": "*",
+        "firefox": "<62",
+        "ie": "*",
+        "ie_mob": "*",
+        "opera": "<56",
+        "safari": "<12",
+        "ios_saf": "<12",
+        "ios_chr": "<69",
+        "android": "<69",
+        "firefox_mob": "<62",
+        "samsung_mob": "*"
+    },
+    "spec": "https://tc39.github.io/proposal-flatMap/#sec-Array.prototype.flatMap",
+    "docs": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
+    "repo": "https://github.com/es-shims/Array.prototype.flatMap",
+    "install": {
+        "module": "array.prototype.flatmap",
+        "paths": [
+            "auto"
+        ]
+    }
+}

--- a/polyfills/Array/prototype/flatMap/detect.js
+++ b/polyfills/Array/prototype/flatMap/detect.js
@@ -1,0 +1,1 @@
+'flatMap' in Array.prototype

--- a/polyfills/Array/prototype/flatMap/tests.js
+++ b/polyfills/Array/prototype/flatMap/tests.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha */
+/* globals proclaim */
+
+it('is a function', function () {
+    proclaim.isFunction(Array.prototype.flatMap);
+});
+
+it('has correct arity', function () {
+    proclaim.arity(Array.prototype.flatMap, 1);
+});
+
+it('has correct name', function () {
+    proclaim.hasName(Array.prototype.flatMap, 'flatMap');
+});
+
+it('is not enumerable', function () {
+    proclaim.isNotEnumerable(Array.prototype, 'flatMap');
+});
+
+describe('callback', function () {
+    it('has correct argument length', function () {
+        [0].flatMap(function () {
+            proclaim.equal(arguments.length, 3);
+        });
+    });
+});
+
+describe('applies callback correctly with', function () {
+    it('arrays', function () {
+        proclaim.equal([4, 5, 7, 12].flatMap(function (v) {
+            return v % 2 === 0 ? [v] : [];
+        }), [4, 12]);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,6 +264,15 @@ array.of@^0.1.1:
   resolved "https://registry.yarnpkg.com/array.of/-/array.of-0.1.1.tgz#8145732d359d65cd2bbf0d8da0caafad3a71ba72"
   integrity sha1-gUVzLTWdZc0rvw2NoMqvrTpxunI=
 
+array.prototype.flatmap@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz#3103cd4826ef90019c9b0a4839b2535fa6faf4e9"
+  integrity sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
+
 arraybuffer.slice@~0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
@@ -1346,6 +1355,13 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -1520,6 +1536,27 @@ error-ex@^1.2.0:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es6-promise@^4.0.3:
   version "4.2.5"
@@ -1951,6 +1988,11 @@ fstream@~1.0.10:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -2117,6 +2159,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2152,6 +2199,13 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has@^1.0.1, has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 he@1.1.1:
   version "1.1.1"
@@ -2346,6 +2400,11 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2359,6 +2418,11 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2498,6 +2562,13 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
+  dependencies:
+    has "^1.0.1"
+
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
@@ -2507,6 +2578,13 @@ is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -3314,6 +3392,11 @@ object-keys@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.5.0.tgz#09e211f3e00318afc4f592e36e7cdc10d9ad7293"
   integrity sha1-CeIR8+ADGK/E9ZLjbnzcENmtcpM=
+
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
+  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
 
 object-visit@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
It's apparently still stage3 proposal, I thought it was already adopted, but I already did the PR :s 
It's implemented on Chrome, Firefox, ..

It looks easy to polyfill, something like `Array.prototype.flatMap = function (fn) { return [].concat(...this.map(fn)) }` but there are corner cases (reminds me of https://github.com/Financial-Times/polyfill-service/pull/1821), so it may be easier to use the official polyfill

Similarly we can add [`Object.fromEntries`](http://npm.im/object.fromentries) (very useful as well) and [`String.prototype.matchAll`](http://npm.im/string.prototype.matchall)