### PR TITLE
Add op_mob to URL polyfill

### DIFF
--- a/polyfills/URL/config.json
+++ b/polyfills/URL/config.json
@@ -17,6 +17,7 @@
 		"safari": "<12",
 		"firefox_mob": "<29",
 		"opera": "<36",
+		"op_mob": "*",
 		"op_mini": "*",
 		"android": "*",
 		"samsung_mob": "<5",


### PR DESCRIPTION
Opera mobile throws `Cannot read property 'append' of undefined`  when you try to run `url.searchParams.append`