### PR TITLE
fix semver to become a valid semver range

### DIFF
--- a/polyfills/DOMTokenList/prototype/@@iterator/config.json
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.json
@@ -2,7 +2,7 @@
 	"browsers": {
 		"edge": "<13",
 		"edge_mob": "<13",
-		"ie": "9-12",
+		"ie": "9 - 12",
 		"ie_mob": "9 - 12",
 		"safari": "<9",
 		"chrome": "<50",


### PR DESCRIPTION
`9-12` is a semver pre-release of version 9.
We actually wanted this to be a range of 9,10,11,12. Which is done via `9 - 12`