### PR TITLE
Use Graceful-fs when updating/building third-party polyfills

### DIFF
--- a/tasks/node/updatesources.js
+++ b/tasks/node/updatesources.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('graceful-fs');
 const path = require('path');
 const denodeify = require('denodeify');
 const glob = denodeify(require('glob'));


### PR DESCRIPTION
This is required to avoid the situation where the polyfill-library have too many file-descriptors open.
Fixes #128