### PR TITLE
Fixes check for -0 in Map.set polyfill

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -337,7 +337,7 @@
 				}
 			}
 			// 6. If key is -0, let key be +0.
-			if (1/key === -Infinity) {
+			if (key === -0) {
 				key = 0;
 			}
 			// 7. Let p be the Record {[[Key]]: key, [[Value]]: value}.


### PR DESCRIPTION
If an object with a null prototype is provided as a key to the `Map` polyfill then a `TypeError` is raised. I think this is expected:

```
$ node
> var key = Object.create(null);
undefined
> 1/key;
TypeError: Cannot convert object to primitive value
```

This code was changed [here](https://github.com/Financial-Times/polyfill-library/commit/65ca84c19359cee11ae5b549233ac85fafc70633#diff-aaebc3d5cda7f687fb935dad9a4a98ea) and I think this is where the bug was introduced as I've tried the previous code (`key === -0`) and it seems to work fine.

