### PR TITLE
chore: update repo and bug urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/financial-times/polyfill-service.git"
+    "url": "https://github.com/financial-times/polyfill-library.git"
   },
   "bugs": {
-    "url": "https://github.com/financial-times/polyfill-service/issues"
+    "url": "https://github.com/financial-times/polyfill-library/issues"
   },
   "scripts": {
     "lint": "eslint polyfills/**/polyfill.js lib tasks test",


### PR DESCRIPTION
Updating the repo and bug url's to point to the new repository since polyfill-library was moved out of polyfill-service.