### PR TITLE
Use require so alias and meta calls are cached

### DIFF
--- a/lib/sources.js
+++ b/lib/sources.js
@@ -3,7 +3,6 @@
 const path = require("path");
 const fs = require("graceful-fs");
 const denodeify = require("denodeify");
-const readFile = denodeify(fs.readFile);
 const readdir = denodeify(fs.readdir);
 
 const polyfillDirectory = path.join(__dirname, "../polyfills/__dist");
@@ -13,12 +12,11 @@ const polyfillDirectory = path.join(__dirname, "../polyfills/__dist");
  * @returns {Promise<Object|undefined>} A promise which resolves with the metadata or with `undefined` if no metadata exists for the polyfill.
  */
 function getPolyfillMeta(featureName) {
-	return readFile(
-			path.join(polyfillDirectory, featureName, "meta.json"),
-			"UTF-8"
-		)
-		.then(JSON.parse)
-		.catch(() => undefined);
+	try {
+		return Promise.resolve(require(path.join(polyfillDirectory, featureName, "meta.json")));
+	} catch(e) {
+		return Promise.resolve();
+	}
 }
 
 /**
@@ -36,7 +34,7 @@ function listPolyfills() {
  * @returns {Promise<Array>} A promise which resolves with an object of all the polyfill aliases within the collection.
  */
 function listAliases() {
-	return readFile(path.join(polyfillDirectory, "aliases.json")).then(JSON.parse);
+	return Promise.resolve(require(path.join(polyfillDirectory, "aliases.json")));
 }
 
 /**


### PR DESCRIPTION
This PR is my take at fixing #147. It -

* Replaces fs.readFile with `require` to take advantage of the fact that the alias and meta files are `json` and that `require` calls will be cached after the first load from disk
* Fixes the tests associated (open to suggestions on the test approach for sure)