### PR TITLE
add typescript types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,54 @@
+import {FeatureList, PolyfillOptions} from "polyfill-library";
+import {ReadStream} from "fs";
+
+declare module "polyfill-library" {
+  /**
+   * this is the config found in /polyfills/polyfill-name/config.json
+   */
+  export type PolyfillConfig = {
+    aliases: string[],
+    browsers: Record<string, string>,
+    spec: string,
+    docs: string,
+
+    license?: "Apache-2.0" | "CC0-1.0" | "ISC" | "MIT" | "WTFPL",
+    notes?: string[],
+    install?: {
+      module?: string,
+      postinstall?: string
+    },
+    detectSource?: string,
+    hasTests?: boolean,
+    isTestable?: boolean,
+    isPublic?: boolean,
+    size?: number,
+  }
+
+  export type FeatureList = {
+    [featureName: string]: {
+      flags?: string[] | Set<string>
+    }
+  }
+
+  export type PolyfillOptions = {
+    minify?: boolean,
+    unknown?: "ignore" | "polyfill",
+    features?: FeatureList,
+    excludes?: string[],
+    uaString?: string,
+    rum?: boolean,
+  };
+
+  export function listAllPolyfills(): Promise<string[]>;
+
+  export function describePolyfill(featureName: String): Promise<PolyfillConfig>;
+
+  export function getOptions(opts: PolyfillOptions): PolyfillOptions;
+
+  export function getPolyfills(opts: PolyfillOptions): Promise<FeatureList>;
+
+  export function getPolyfillString(opts: PolyfillOptions & {stream: false}): Promise<string>;
+  export function getPolyfillString(opts: PolyfillOptions): Promise<string>;
+  export function getPolyfillString(opts: PolyfillOptions & {stream: true}): ReadStream;
+  export function getPolyfillString(opts: PolyfillOptions & {stream?: boolean}): Promise<string> | ReadStream;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.30.1",
   "description": "A polyfill combinator",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "contributors": [
     {
       "name": "Jonathan Neal",


### PR DESCRIPTION
Hi,

This PR adds typings for typescript. I deduced them mainly from the description in the README.

I can't provide a test-plan/tests. I don't think there's a good way to test typescript definitions at all.

I used these definitions in our typescript project (with strict settings etc.), that's my testcase ;)