### PR TITLE
Removing the typeof check with early return because it is handled via the `new Event` check, which is more thorough and will correctly detect bad Event constructors in Android 4.x

### DIFF
--- a/polyfills/Event/detect.js
+++ b/polyfills/Event/detect.js
@@ -1,11 +1,10 @@
 (function(global) {
 
 	if (!('Event' in global)) return false;
-	if (typeof global.Event === 'function') return true;
 
 	try {
 
-		// In IE 9-11, the Event object exists but cannot be instantiated
+		// In IE 9-11 and Android 4.x, the Event object exists but cannot be instantiated
 		new Event('click');
 		return true;
 	} catch(e) {


### PR DESCRIPTION


Fixes https://github.com/Financial-Times/polyfill-library/issues/19