### PR TITLE
Update Object.is browser versions

### DIFF
--- a/polyfills/Object/is/config.json
+++ b/polyfills/Object/is/config.json
@@ -5,20 +5,20 @@
 		"modernizr:es6object"
 	],
 	"browsers": {
-		"android": "<4.4",
+		"android": "< 4.4",
 		"bb": "*",
-		"chrome": "1 - 29",
-		"edge": "<12",
-		"edge_mob": "<14",
-		"firefox": "3.6 - 21",
+		"chrome": "< 29",
+		"edge": "< 12",
+		"edge_mob": "< 14",
+		"firefox": "< 22",
+		"firefox_mob": "< 22",
 		"ie": "*",
-		"ie_mob": "10 - *",
-		"opera": "<32",
+		"ie_mob": "*",
+		"opera": "< 32",
 		"op_mini": "*",
-		"op_mob": "*",
-		"safari": "<9",
-		"ios_saf": "<9",
-		"firefox_mob": "3.6 - 21"
+		"op_mob": "< 32",
+		"safari": "< 9",
+		"ios_saf": "< 9"
 	},
 	"dependencies": [
 		"_ESAbstract.CreateMethodProperty",

--- a/polyfills/Object/is/config.json
+++ b/polyfills/Object/is/config.json
@@ -5,19 +5,19 @@
 		"modernizr:es6object"
 	],
 	"browsers": {
-		"android": "*",
+		"android": "<4.4",
 		"bb": "*",
 		"chrome": "1 - 29",
-		"edge": "*",
-		"edge_mob": "*",
+		"edge": "<12",
+		"edge_mob": "<14",
 		"firefox": "3.6 - 21",
 		"ie": "*",
 		"ie_mob": "10 - *",
 		"opera": "<32",
 		"op_mini": "*",
 		"op_mob": "*",
-		"safari": "*",
-		"ios_saf": "*",
+		"safari": "<9",
+		"ios_saf": "<9",
 		"firefox_mob": "3.6 - 21"
 	},
 	"dependencies": [


### PR DESCRIPTION
Based on:
- http://kangax.github.io/compat-table/es6/#test-Object_static_methods_Object.is
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is

Edge mobile version is set when desktop version supports it