### PR TITLE
Rename opera_mob to op_mob in Set and Map polyfills config

### DIFF
--- a/polyfills/Map/config.json
+++ b/polyfills/Map/config.json
@@ -14,7 +14,7 @@
 		"firefox_mob": "<29",
 		"ie_mob": "*",
 		"opera": "<25",
-		"opera_mob": "*",
+		"op_mob": "*",
 		"op_mini": "*",
 		"ios_saf": "<9",
 		"bb": "10 - *"

--- a/polyfills/Set/config.json
+++ b/polyfills/Set/config.json
@@ -14,7 +14,7 @@
 		"firefox_mob": "<29",
 		"ie_mob": "*",
 		"opera": "<25",
-		"opera_mob": "*",
+		"op_mob": "*",
 		"op_mini": "*",
 		"ios_saf": "<9",
 		"bb": "10 - *"


### PR DESCRIPTION
a `op_mob` code is used in a project to identify Opera Mini browser, i guess it's just a typo.