### PR TITLE
({}).toString.call(null) should not be [object Window] (alternative)

### DIFF
--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -213,6 +213,7 @@
 	defineProperty(Object, 'create', descriptor);
 
 	descriptor.value = function () {
+		'use strict'; //so that ({}).toString.call(null) returns the correct [object Null] rather than [object Window]
 		var str = toString.call(this);
 		return (str === '[object String]' && onlySymbols(this)) ? '[object Symbol]' : str;
 	};

--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -2,6 +2,7 @@
 // (C) Andrea Giammarchi - MIT Licensed
 
 (function (Object, GOPS, global) {
+	'use strict'; //so that ({}).toString.call(null) returns the correct [object Null] rather than [object Window]
 
 	var	setDescriptor;
 	var id = 0;
@@ -213,12 +214,10 @@
 	defineProperty(Object, 'create', descriptor);
 
 	descriptor.value = function () {
-		'use strict'; //so that ({}).toString.call(null) returns the correct [object Null] rather than [object Window]
 		var str = toString.call(this);
 		return (str === '[object String]' && onlySymbols(this)) ? '[object Symbol]' : str;
 	};
 	defineProperty(ObjectProto, 'toString', descriptor);
-
 
 	setDescriptor = function (o, key, descriptor) {
 		var protoDescriptor = gOPD(ObjectProto, key);

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -58,6 +58,10 @@ it('should return "[object Symbol]" when called with Object.prototype.toString()
 	proclaim.equal(Object.prototype.toString.call(Symbol()), '[object Symbol]');
 });
 
+it('should retain browser toString behavior for nulls', function() {
+	proclaim.equal(Object.prototype.toString.call(null), '[object Null]');
+});
+
 if (supportsDescriptors) {
 	it('should silently fail when overwriting properties', function() {
 		var sym = Symbol("2");

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -58,9 +58,22 @@ it('should return "[object Symbol]" when called with Object.prototype.toString()
 	proclaim.equal(Object.prototype.toString.call(Symbol()), '[object Symbol]');
 });
 
-it('should retain browser toString behavior for nulls', function() {
-	proclaim.equal(Object.prototype.toString.call(null), '[object Null]');
-});
+if(document.documentMode && document.documentMode <= 8) {
+	it('IE8: Object.prototype.toString.call(window) should be [object Object]', function() {
+		proclaim.equal(Object.prototype.toString.call(window), '[object Object]');
+	});
+} else if(document.documentMode && document.documentMode === 9) {
+	it('IE9: Object.prototype.toString.call(window) should be [object Window]', function() {
+		proclaim.equal(Object.prototype.toString.call(window), '[object Window]');
+	});
+} else {
+	it('Object.prototype.toString.call(null) should be [object Null]', function() {
+		proclaim.equal(Object.prototype.toString.call(null), '[object Null]');
+	});
+	it('Object.prototype.toString.call(window) should be [object Window]', function() {
+		proclaim.equal(Object.prototype.toString.call(window), '[object Window]');
+	});
+}
 
 if (supportsDescriptors) {
 	it('should silently fail when overwriting properties', function() {


### PR DESCRIPTION
Alternative to #193; fixes #164.

For old-IE, there's no use strict, and this PR accepts the current behavior of that `Object.prototype.toString.call(null)` (and `Object.prototype.toString.call(window)`) both return `[object Window]` on IE9, and `[object Object]` on IE8.  For IE10, IE11, and modern browsers this PR and #193 behave identically: `Object.prototype.toString.call(window) === '[object Window]'` and `Object.prototype.toString.call(null) === '[object Null]'`.

In essence: for IE8+9 the Symbol polyfill necessarily introduces a bug into toString.  Current behavior makes `null` wrong.  This PR keeps that bug; the alternative #193 fixed the `null` argument, but breaks `window`.  But either PR fixes the bug for IE10 and newer.