### PR TITLE
Optimise CI testing for third-party-polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -395,6 +395,17 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "array.prototype.flatmap": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz",
+      "integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
+      }
+    },
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
@@ -1090,6 +1101,23 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -1293,6 +1321,39 @@
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "es6-promise": {
       "version": "4.2.5",
@@ -2483,6 +2544,12 @@
         "rimraf": "2"
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -2602,6 +2669,15 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2638,6 +2714,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-value": {
@@ -2861,6 +2943,12 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -2869,6 +2957,12 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -2940,6 +3034,15 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -2951,6 +3054,15 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-url": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "yaku": "0.18.6"
   },
   "devDependencies": {
+    "array.prototype.flatmap": "^1.2.1",
     "dotenv": "^6.2.0",
     "eslint": "^4.9.0",
     "execa": "^1.0.0",

--- a/test/polyfills/test-individual-feature.js
+++ b/test/polyfills/test-individual-feature.js
@@ -7,40 +7,48 @@ const feature = process.argv.slice(2)[0];
 
 const featureToFolder = feature => feature.replace(/\./g, path.sep);
 
-(async function () {
-    try {
-        const filesWhichChanged = execa.shellSync('git diff --name-only origin/master').stdout.split('\n');
-        // if any of the dependencies in the tree from the feature is the same as latest commit, run the tests
-        const dependencies = Object.keys(await polyfillLibrary.getPolyfills({
-            features: {
-                [feature]: {}
-            },
-            unknown: 'polyfill',
-            uaString: ''
-        })).map(feature => `polyfills/${featureToFolder(feature)}`);
+async function featureRequiresTesting(feature) {
+    const filesWhichChanged = execa.shellSync('git diff --name-only origin/master').stdout.split('\n');
+    // if any of the dependencies in the tree from the feature is the same as latest commit, run the tests
+    const dependencies = Object.keys(await polyfillLibrary.getPolyfills({
+        features: {
+            [feature]: {}
+        },
+        unknown: 'polyfill',
+        uaString: ''
+    })).map(feature => `polyfills/${featureToFolder(feature)}`);
 
-        const configs = dependencies.map(d => d + '/config.json');
-        const polyfills = dependencies.map(d => d + '/polyfill.js');
-        const detects = dependencies.map(d => d + '/detect.js');
-        const tests = dependencies.map(d => d + '/tests.js');
-        const files = [].concat(configs, polyfills, detects, tests);
+    const configs = dependencies.map(d => d + '/config.json');
+    const polyfills = dependencies.map(d => d + '/polyfill.js');
+    const detects = dependencies.map(d => d + '/detect.js');
+    const tests = dependencies.map(d => d + '/tests.js');
+    const files = [].concat(configs, polyfills, detects, tests);
 
-        if (!files.some(file => filesWhichChanged.includes(file))) {
-            if (!filesWhichChanged.some(file => file.startsWith('lib/'))) {
-                if (!filesWhichChanged.some(file => file.startsWith('karma-polyfill-library-plugin.js'))) {
-                    if (!filesWhichChanged.some(file => file.startsWith('package.json'))) {
-                        console.log(`${feature} has not changed, no need to run the tests.`);
-                        process.exit(0);
-                    }
+    if (!files.some(file => filesWhichChanged.includes(file))) {
+        if (!filesWhichChanged.some(file => file.startsWith('lib/'))) {
+            if (!filesWhichChanged.some(file => file.startsWith('karma-polyfill-library-plugin.js'))) {
+                if (!filesWhichChanged.some(file => file.startsWith('package.json'))) {
+                    return false;
                 }
             }
         }
+    }
 
-        console.log(`Testing ${feature}`);
-        const result = execa('karma', ['start', path.join(__dirname, '../../', 'karma.conf.js'), `--browserstack`, `--features=${feature}`]);
-        result.stdout.pipe(process.stdout);
-        result.stderr.pipe(process.stderr);
-        await result;
+    return true;
+}
+
+(async function () {
+    try {
+        if (await featureRequiresTesting(feature)) {
+            console.log(`Testing ${feature}`);
+            const result = execa('karma', ['start', path.join(__dirname, '../../', 'karma.conf.js'), `--browserstack`, `--features=${feature}`]);
+            result.stdout.pipe(process.stdout);
+            result.stderr.pipe(process.stderr);
+            await result;
+        } else {
+            console.log(`${feature} has not changed, no need to run the tests.`);
+            process.exit(0);
+        }
     } catch (err) {
         console.log(`Errors found testing ${feature}`);
         console.error(err.stderr || err.stdout);


### PR DESCRIPTION
Currently when a change is made to the package.json file it will cause all the tests within the project to be executed in CI, which is painfully painfully slow and labor-intensive. This is a real issue for the project because we have the ability to use an npm package as the source of a polyfill (known as third-party-polyfills) and this is used more and more by contributors to the project.

We can speed up the scenario where a third-party-polyfill has been added or updated within the project by making the CI test-runner aware of the changes made within the package.json file and figure out if the changes were for a third-party-polyfill or not.