### PR TITLE
Add Object.getOwnPropertyDescriptors to the es2017 alias

### DIFF
--- a/polyfills/Object/getOwnPropertyDescriptors/config.toml
+++ b/polyfills/Object/getOwnPropertyDescriptors/config.toml
@@ -1,4 +1,6 @@
-aliases = []
+aliases = [
+    "es2017"
+]
 dependencies = [
     "Object.getOwnPropertyDescriptor",
     "Object.defineProperty",


### PR DESCRIPTION
It was added in the ECMA262 2017 edition -- https://www.ecma-international.org/ecma-262/8.0/#sec-object.getownpropertydescriptors