### PR TITLE
Polyfill IntersectionObserver on Safari < 12.1

### DIFF
--- a/polyfills/IntersectionObserver/config.toml
+++ b/polyfills/IntersectionObserver/config.toml
@@ -29,6 +29,6 @@ ie_mob = "*"
 ios_saf = "< 12.1"
 op_mini = "*"
 opera = "< 45"
-safari = "< 12.0"
+safari = "< 12.1"
 samsung_mob = "< 7"
 


### PR DESCRIPTION
[`IntersectionObserver` is not available on Safari 12.0](https://caniuse.com/#feat=intersectionobserver), only from 12.1 onwards.

Fixes https://github.com/Financial-Times/polyfill-library/issues/285