### PR TITLE
Polyfill Object.keys for IE11

### DIFF
--- a/polyfills/Object/keys/config.toml
+++ b/polyfills/Object/keys/config.toml
@@ -15,11 +15,10 @@ docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global
 spec = "https://tc39.github.io/ecma262/#sec-object.keys"
 
 [browsers]
-ie = "<11"
+ie = "*"
 safari = "<9"
 chrome = "<47"
 opera = "<34"
 firefox = "<38"
 firefox_mob = "<4"
 ios_saf = "<9"
-


### PR DESCRIPTION
`Object.keys` must be polyfilled for IE11 because although that function exists, it uses the ES5 behavior where only object arguments are allowed.

Closes #294