### PR TITLE
Load AbortController for all version of Samsung browser

### DIFF
--- a/polyfills/AbortController/config.toml
+++ b/polyfills/AbortController/config.toml
@@ -26,8 +26,8 @@ safari = "3.1 - 12"
 chrome = "4 - 65"
 ios_saf = "3.2 - 11.2"
 firefox_mob = "<64"
-android = "<67"
 samsung_mob = "*"
+android = "<67"
 
 [install]
 module = "abort-controller"

--- a/polyfills/AbortController/config.toml
+++ b/polyfills/AbortController/config.toml
@@ -27,6 +27,7 @@ chrome = "4 - 65"
 ios_saf = "3.2 - 11.2"
 firefox_mob = "<64"
 android = "<67"
+samsung_mob = "*"
 
 [install]
 module = "abort-controller"


### PR DESCRIPTION
Fixes #334 .

Samsung Internet does not support AbortController at all [source from MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).