### PR TITLE
Ensure all code which runs in a browser environment is written in ES3 syntax

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,35 +5,24 @@ polyfills/__dist/**
 # We do not ignore the config.json, detect.js or tests.js
 # because we do control their implementation.
 
-polyfills/_ArrayIterator/polyfill.js
 polyfills/_TypedArray/polyfill.js
-polyfills/Array/of/polyfill.js
-polyfills/Array/prototype/values/polyfill.js
 polyfills/atob/polyfill.js
 polyfills/AudioContext/polyfill.js
-polyfills/fetch/polyfill.js
 polyfills/Element/prototype/inert/polyfill.js
 polyfills/EventSource/polyfill.js
 polyfills/fetch/polyfill.js
-polyfills/Function/prototype/bind/polyfill.js
 polyfills/HTMLPictureElement/polyfill.js
-polyfills/IntersectionObserver/polyfill.js
 polyfills/Intl/polyfill.js
 polyfills/Intl/~locale/**/polyfill.js
 polyfills/JSON/polyfill.js
-polyfills/navigator/sendBeacon/polyfill.js
 polyfills/MutationObserver/polyfill.js
 polyfills/Promise/polyfill.js
-polyfills/setImmediate/polyfill.js
-polyfills/String/fromCodePoint/polyfill.js
 polyfills/String/prototype/normalize/polyfill.js
 polyfills/UserTiming/polyfill.js
-polyfills/WeakSet/polyfill.js
 polyfills/~html5-elements/polyfill.js
 polyfills/WebAnimations/polyfill.js
 tasks/**/node_modules
 polyfills/**/detect.js
-polyfills/Event/focusin/detect-disabled.js
 polyfills/HTMLTemplateElement/polyfill.js
 polyfills/ResizeObserver/polyfill.js
 polyfills/AbortController/polyfill.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -22,7 +22,6 @@ polyfills/UserTiming/polyfill.js
 polyfills/~html5-elements/polyfill.js
 polyfills/WebAnimations/polyfill.js
 tasks/**/node_modules
-polyfills/**/detect.js
 polyfills/HTMLTemplateElement/polyfill.js
 polyfills/ResizeObserver/polyfill.js
 polyfills/AbortController/polyfill.js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/financial-times/polyfill-library/issues"
   },
   "scripts": {
-    "lint": "eslint polyfills/**/polyfill.js lib tasks test",
+    "lint": "eslint polyfills lib tasks test",
     "clean": "rimraf ./polyfills/__dist",
     "build": "npm run clean && node tasks/node/updatesources && node tasks/node/buildsources",
     "build-circleci-config": "node ./tasks/node/build-circleci-config.js",

--- a/polyfills/.eslintrc
+++ b/polyfills/.eslintrc
@@ -1,43 +1,19 @@
 {
-	"env": {
-		"es6": false,
-		"browser": true,
-		"node": false
-	},
-	"parserOptions": {
-		"ecmaVersion": 3
-	},
-	"rules": {
-		"no-unused-vars": 2,
-		"no-undef": 1,
-		"eqeqeq": 0,
-		"guard-for-in": 0,
-		"no-extend-native": 0,
-		"wrap-iife": 2,
-		"new-cap": 0,
-		"no-caller": 2,
-		"no-multi-str": 0,
-		"dot-notation": 0,
-		"semi": [2, "always"],
-		"strict": [0],
-		"valid-jsdoc": 0,
-		"no-irregular-whitespace": 1,
-		"no-multi-spaces": 2,
-		"one-var": 0,
-		"constructor-super": 2,
-		"no-this-before-super": 2,
-		"no-var": 0,
-		"prefer-const": 0,
-		"no-const-assign": 0
-	},
-	"globals": {
-		"ActiveXObject": true,
-		"ArrayIterator": true,
-		"_DOMTokenList": true,
-		"_mutation": true,
-		"mozRequestAnimationFrame": true,
-		"mozCancelAnimationFrame": true,
-		"webkitRequestAnimationFrame": true,
-		"webkitCancelAnimationFrame": true
-	}
+  "env": {
+    "es6": false,
+    "browser": true,
+    "node": false
+  },
+  "parserOptions": {
+    "ecmaVersion": 3,
+    "sourceType": "script"
+  },
+  "rules": {
+	"comma-dangle"          : [ 2, "never" ],
+	"quote-props"           : [ 2, "as-needed", { "keywords" : true } ],
+	"dot-notation"          : [ 2, { "allowKeywords" : false } ],
+	"radix"                 : 2,
+	"no-catch-shadow"       : 2
+  },
+  "root": true
 }

--- a/polyfills/Array/from/polyfill.js
+++ b/polyfills/Array/from/polyfill.js
@@ -70,7 +70,7 @@
 				// iv. If next is false, then
 				if (next === false) {
 					// 1. Perform ? Set(A, "length", k, true).
-					A["length"] = k;
+					A.length = k;
 					// 2. Return A.
 					return A;
 				}
@@ -145,7 +145,7 @@
 			k = k + 1;
 		}
 		// 13. Perform ? Set(A, "length", len, true).
-		A["length"] = len;
+		A.length = len;
 		// 14. Return A.
 		return A;
 	});

--- a/polyfills/Array/from/tests.js
+++ b/polyfills/Array/from/tests.js
@@ -197,41 +197,41 @@ describe('returns an array with', function () {
 
 describe('throws', function () {
 	it('non-iterable objects', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from();
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from(undefined);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from(null);
 		});
 	});
 
 	it('specified, invalid mapping functions', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from([1, 2, 3], null);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from([1, 2, 3], /\*/);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from([1, 2, 3], '');
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from([1, 2, 3], []);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from([1, 2, 3], {});
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.from([1, 2, 3], 3);
 		});
 	});

--- a/polyfills/Array/of/polyfill.js
+++ b/polyfills/Array/of/polyfill.js
@@ -31,7 +31,7 @@ CreateMethodProperty(Array, 'of', function of() {
 
 	}
 	// 8. Perform ? Set(A, "length", len, true)
-	A["length"] = len;
+	A.length = len;
 	// 9. Return A.
 	return A;
 });

--- a/polyfills/Array/prototype/copyWithin/tests.js
+++ b/polyfills/Array/prototype/copyWithin/tests.js
@@ -90,13 +90,13 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('throws if called with null context', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			return Array.prototype.copyWithin.call(null, 0);
 		}, TypeError);
 	});
 
 	it('throws if called with undefined context', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			return Array.prototype.copyWithin.call(undefined, 0);
 		}, TypeError);
 	});

--- a/polyfills/Array/prototype/filter/tests.js
+++ b/polyfills/Array/prototype/filter/tests.js
@@ -22,10 +22,10 @@ var stringsOnly = function(val) {
 };
 
 it('throws a TypeError when applied to non-array-like types', function() {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		Array.prototype.filter.call(undefined);
 	}, TypeError);
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		Array.prototype.filter.call(null);
 	}, TypeError);
 });

--- a/polyfills/Array/prototype/flat/tests.js
+++ b/polyfills/Array/prototype/flat/tests.js
@@ -24,25 +24,25 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if constructor property is neither undefined nor an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = null;
         a.flat();
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = 1;
         a.flat();
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = 'string';
         a.flat();
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = true;
         a.flat();
@@ -51,24 +51,24 @@ it('throws a TypeError if constructor property is neither undefined nor an Objec
 
 if (supportsStrictModeTests) {
     it('throws TypeError if thisArg is null', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             [].flat.call(null);
         }, TypeError);
     });
     it('throws TypeError if thisArg is missing', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             [].flat.call();
         }, TypeError);
     });
     it('throws TypeError if thisArg is undefined', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             [].flat.call(undefined);
         }, TypeError);
     });
 }
 if ('Symbol' in self) {
     it('throws TypeError if argument is a Symbol', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             [].flat(Symbol());
         }, TypeError);
     });
@@ -184,11 +184,11 @@ it('can be rebound', function () {
 it('works with array-like objects', function () {
     proclaim.deepStrictEqual([].flat.call({
         length: 1,
-        0: [1],
+        0: [1]
     }), [1]);
 
     proclaim.deepStrictEqual([].flat.call({
         length: undefined,
-        0: [1],
+        0: [1]
     }), []);
 });

--- a/polyfills/Array/prototype/flatMap/tests.js
+++ b/polyfills/Array/prototype/flatMap/tests.js
@@ -25,68 +25,68 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
     it('throws TypeError if thisArg is null', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             [].flatMap.call(null, function () {});
         }, TypeError);
     });
 
     it('throws TypeError if thisArg is undefined', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             [].flatMap.call(undefined, function () {});
         }, TypeError);
     });
 }
 
 it('throws TypeError if argument is not callable', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap({});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap(0);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap();
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap(undefined);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap(null);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap(false);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         [].flatMap('');
     }, TypeError);
 });
 
 it('throws a TypeError if constructor property is neither undefined nor an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = null;
         a.flatMap(function () {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = 1;
         a.flatMap(function () {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = 'string';
         a.flatMap(function () {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         var a = [];
         a.constructor = true;
         a.flatMap(function () {});

--- a/polyfills/Array/prototype/includes/tests.js
+++ b/polyfills/Array/prototype/includes/tests.js
@@ -78,10 +78,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.prototype.includes.call(null, 0);
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Array.prototype.includes.call(void 8, 0);
 		}, TypeError);
 	}

--- a/polyfills/Array/prototype/reduce/tests.js
+++ b/polyfills/Array/prototype/reduce/tests.js
@@ -50,13 +50,13 @@ it('should not affect elements added to the array after it has begun', function 
 	proclaim.equal(i, 2);
 });
 it('should work as expected for empty arrays', function () {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		[].reduce(spy);
 	});
 	proclaim.equal(spycalls.length, 0);
 });
 it('should throw correctly if no callback is given', function () {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		[1,2,3].reduce();
 	});
 });

--- a/polyfills/Array/prototype/reduceRight/tests.js
+++ b/polyfills/Array/prototype/reduceRight/tests.js
@@ -50,13 +50,13 @@ it('should not affect elements added to the array after it has begun', function 
 	proclaim.equal(i, 2);
 });
 it('should work as expected for empty arrays', function () {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		[].reduceRight(spy);
 	});
 	proclaim.equal(spycalls.length, 0);
 });
 it('should throw correctly if no callback is given', function () {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		[1,2,3].reduceRight();
 	});
 });

--- a/polyfills/Array/prototype/some/tests.js
+++ b/polyfills/Array/prototype/some/tests.js
@@ -23,7 +23,7 @@ beforeEach(function() {
 
 it("Should not accept a function argument that is not callable", function() {
 	var array = this.array;
-	proclaim.throws(function() { array.some({}); }, TypeError);
+	proclaim["throws"](function() { array.some({}); }, TypeError);
 });
 
 it("Should accept a function with three parameters: the value of the element, the index of the element and the object being traversed", function() {

--- a/polyfills/Array/prototype/values/tests.js
+++ b/polyfills/Array/prototype/values/tests.js
@@ -16,7 +16,7 @@ it('has correct name', function () {
 		// Chrome 40 implements the Symbol.iterator function for Arrays but has it named ArrayValues.
 		try {
 			proclaim.equal([].values.name, 'ArrayValues');
-		} catch (e) {
+		} catch (er) {
 			// Firefox 44 has it named [Symbol.iterator].
 			proclaim.equal([].values.name, '[Symbol.iterator]');
 		}

--- a/polyfills/Blob/tests.js
+++ b/polyfills/Blob/tests.js
@@ -15,84 +15,84 @@ describe('Blob', function () {
 	});
 
 	it('throws an error if called without `new` operator', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Blob();
 		}, TypeError);
 	});
 
 	it('throws an error if called with null', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(null);
 		}, TypeError);
 	});
 
 	it('throws an error if called with true', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(true);
 		}, TypeError);
 	});
 
 	it('throws an error if called with false', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(false);
 		}, TypeError);
 	});
 
 	it('throws an error if called with 0', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(0);
 		}, TypeError);
 	});
 
 	it('throws an error if called with 1', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(1);
 		}, TypeError);
 	});
 
 	it('throws an error if called with decimal number', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(1.5);
 		}, TypeError);
 	});
 
 	it('throws an error if called with a string', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob('fail');
 		}, TypeError);
 	});
 
 	it('throws an error if called with a date', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(new Date());
 		}, TypeError);
 	});
 
 	it('throws an error if called with a RegExp', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(new RegExp());
 		}, TypeError);
 	});
 
 	// This requires rewriting the polyfill to take into account iterable objects defined via Symbol.iterator instead of being based on blobParts.length property
 	it.skip('throws an error if called with an object', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob({});
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob({ 0: 'fail', length: 1 });
 		}, TypeError);
 	});
 
 	it('throws an error if called with a div', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(document.createElement('div'));
 		}, TypeError);
 	});
 
 	// This requires rewriting the polyfill to take into account iterable objects defined via Symbol.iterator instead of being based on blobParts.length property
 	it.skip('throws an error if called with window', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob(window);
 		}, TypeError);
 	});
@@ -122,25 +122,25 @@ describe('Blob', function () {
 	});
 
 	it('should throw if second argument is an integer', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob([], 12345);
 		}, TypeError);
 	});
 
 	it('should throw if second argument is an decimal number', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob([], 1.2);
 		}, TypeError);
 	});
 
 	it('should throw if second argument is an boolean', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob([], true);
 		}, TypeError);
 	});
 
 	it('should throw if second argument is an string', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			new Blob([], '12345');
 		}, TypeError);
 	});

--- a/polyfills/CustomEvent/tests.js
+++ b/polyfills/CustomEvent/tests.js
@@ -11,7 +11,7 @@ it('should have an initCustomEvent function', function() {
 // Safari allows you to instantiate with no parameters, all this means is you create an event that you can never
 // listen for - pointless, but will not break anything...
 it.skip('should throw exception when instantiated with no parameters', function() {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		new CustomEvent();
 	});
 });

--- a/polyfills/Element/prototype/closest/tests.js
+++ b/polyfills/Element/prototype/closest/tests.js
@@ -75,7 +75,7 @@ if (!!document.createElementNS && !!document.createElementNS('http://www.w3.org/
 it.skip("should throw an error if the selector syntax is incorrect", function() {
 	var el = document.body.appendChild(document.createElement("a"));
 
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		el.closest("p<incorrectselector:><");
 	});
 

--- a/polyfills/Element/prototype/toggleAttribute/tests.js
+++ b/polyfills/Element/prototype/toggleAttribute/tests.js
@@ -14,7 +14,7 @@ describe('Element.prototype.toggleAttribute', function() {
 
     // TODO: IE8 does not throw any error. Should throw INVALID_CHARACTER_ERR. Should we support this?
     it.skip("should throw an error if the attribute name is not valid", function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             el.toggleAttribute('$');
         });
     });

--- a/polyfills/Event/tests.js
+++ b/polyfills/Event/tests.js
@@ -5,7 +5,7 @@
 // as it would just create an event that can never be dispatched/listened for
 // it doesn't cause any problem
 it.skip('should throw exception when instantiated with no parameters', function() {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		new Event();
 	});
 });

--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -551,6 +551,6 @@
 	} catch (e) {
 		// IE8 throws an error here if we set enumerable to false.
 		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global['Map'] = Map;
+		global.Map = Map;
 	}
 }(this));

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -241,7 +241,7 @@ describe('Map', function () {
 		});
 
 		it('throws error if called without NewTarget set. I.E. Called as a normal function and not a constructor', function () {
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map(); // eslint-disable-line new-cap
 			});
 		});
@@ -327,31 +327,31 @@ describe('Map', function () {
 		});
 
 		it('throws a TypeError if `this` is not an Object', function () {
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call('');
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call(1);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call(true);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call(/ /);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call(null);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call(undefined);
 			}, TypeError);
 		});
 
 		it('throws a TypeError if `this` is not an a Map Object', function () {
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call([]);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype.clear.call({});
 			}, TypeError);
 		});
@@ -367,31 +367,31 @@ describe('Map', function () {
 		});
 
 		it('throws a TypeError if `this` is not an Object', function () {
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call('');
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call(1);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call(true);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call(/ /);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call(null);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call(undefined);
 			}, TypeError);
 		});
 
 		it('throws a TypeError if `this` is not an a Map Object', function () {
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call([]);
 			}, TypeError);
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				Map.prototype['delete'].call({});
 			}, TypeError);
 		});

--- a/polyfills/Node/prototype/contains/tests.js
+++ b/polyfills/Node/prototype/contains/tests.js
@@ -33,7 +33,7 @@ describe('on an element', function () {
 
 	// Native implementations on Safari (desktop and iOS) as of v9 return false when no argument is supplied
 	it.skip('throws when missing the argument', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			documentElement.contains();
 		});
 	});
@@ -60,7 +60,7 @@ describe('on the document', function () {
 
 	// Native implementations on Safari (desktop and iOS) as of v9 return false when no argument is supplied
 	it.skip('throws when missing the argument', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			document.contains();
 		});
 	});

--- a/polyfills/Number/parseInt/tests.js
+++ b/polyfills/Number/parseInt/tests.js
@@ -17,8 +17,8 @@ it('returns NaN with NaN values', function () {
 it('returns 15 for valid numbers and non-number data types', function () {
 	proclaim.equal(Number.parseInt(15, 10), 15);
 	proclaim.equal(Number.parseInt("15", 10), 15);
-  proclaim.equal(Number.parseInt("15"), 15);
-  proclaim.equal(Number.parseInt("15px"), 15);
-  proclaim.equal(Number.parseInt("15.2"), 15);
-  proclaim.equal(Number.parseInt("0xf"), 15);
+  	proclaim.equal(Number.parseInt("15"), 15); // eslint-disable-line radix
+  	proclaim.equal(Number.parseInt("15px"), 15); // eslint-disable-line radix
+  	proclaim.equal(Number.parseInt("15.2"), 15); // eslint-disable-line radix
+  	proclaim.equal(Number.parseInt("0xf"), 15); // eslint-disable-line radix
 });

--- a/polyfills/Object/assign/tests.js
+++ b/polyfills/Object/assign/tests.js
@@ -6,11 +6,11 @@ it('has the correct length', function() {
 });
 
 it('throws when target is not an object', function() {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.assign(null);
 	}, TypeError);
 
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.assign(undefined);
 	}, TypeError);
 });
@@ -32,15 +32,15 @@ it('Ignores null and undefined sources', function () {
 });
 
 it('throws on null or undefined targets', function() {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.assign(null, {});
 	});
 
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.assign(undefined, {});
 	});
 
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.assign(undefined, undefined);
 	});
 });

--- a/polyfills/Object/create/tests.js
+++ b/polyfills/Object/create/tests.js
@@ -22,7 +22,7 @@ it("Should create inherited object from a Native Object", function() {
 });
 
 it("Should throw a TypeError if called with undefined", function() {
-	proclaim.throws(function() { Object.create(undefined); }, TypeError);
+	proclaim["throws"](function() { Object.create(undefined); }, TypeError);
 });
 
 it("Should create an object if called with null", function() {
@@ -30,11 +30,11 @@ it("Should create an object if called with null", function() {
 });
 
 it("Should throw a TypeError if called with a boolean primitive", function() {
-	proclaim.throws(function() { Object.create(true); }, TypeError);
+	proclaim["throws"](function() { Object.create(true); }, TypeError);
 });
 
 it("Should throw a TypeError if called with a number primitive", function() {
-	proclaim.throws(function() { Object.create(100); }, TypeError);
+	proclaim["throws"](function() { Object.create(100); }, TypeError);
 });
 
 it("Should not throw a TypeError if called with Function objects", function() {

--- a/polyfills/Object/defineProperty/polyfill.js
+++ b/polyfills/Object/defineProperty/polyfill.js
@@ -5,7 +5,7 @@
 	var ERR_VALUE_ACCESSORS = 'A property cannot both have accessors and be writable or have a value';
 
 	// Polyfill.io - This does not use CreateMethodProperty because our CreateMethodProperty function uses Object.defineProperty.
-	Object['defineProperty'] = function defineProperty(object, property, descriptor) {
+	Object.defineProperty = function defineProperty(object, property, descriptor) {
 
 		// Where native support exists, assume it
 		if (nativeDefineProperty && (object === window || object === document || object === Element.prototype || object instanceof Element)) {

--- a/polyfills/Object/defineProperty/tests.js
+++ b/polyfills/Object/defineProperty/tests.js
@@ -98,29 +98,29 @@ describe('Error handling', function () {
 	value = 'bar';
 
 	it('Throws an error when called on a non-object', function() {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty();
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(undefined);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(null);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty('');
 		});
 	});
 
 	it('Throws an error when descriptor is a non-object', function() {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, undefined);
 		});
 
@@ -129,17 +129,17 @@ describe('Error handling', function () {
 		//	Object.defineProperty(object, property, null);
 		//});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, '');
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property);
 		}, /^Property description must be an object/);
 	});
 
 	it('Throws an error when both an accessor and a value are specified', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, {
 				value: value,
 				writable: true,
@@ -149,7 +149,7 @@ describe('Error handling', function () {
 			});
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, {
 				value: value,
 				writable: true,
@@ -161,28 +161,28 @@ describe('Error handling', function () {
 	});
 
 	it('Throws an error when an accessor is specified and writable is set', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, {
 				get: function () {},
 				writable: false
 			});
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, {
 				get: function () {},
 				writable: true
 			});
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, {
 				set: function () {},
 				writable: false
 			});
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			Object.defineProperty(object, property, {
 				set: function () {},
 				writable: true

--- a/polyfills/Object/entries/tests.js
+++ b/polyfills/Object/entries/tests.js
@@ -54,7 +54,7 @@ var objectKeysWorksWithPrimitives = (function() {
 
 if (supportsDescriptors) {
 	it('should terminate if getting a value throws an exception', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			var obj = {};
 			Object.defineProperty(obj, 'a', {
 				enumerable: true,
@@ -74,13 +74,13 @@ if (supportsDescriptors) {
 }
 
 it('should throw TypeError when called with `null`', function() {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		Object.entries(null);
 	}, TypeError);
 });
 
 it('should throw TypeError when called with `undefined`', function() {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		Object.entries(undefined);
 	}, TypeError);
 });

--- a/polyfills/Object/fromEntries/tests.js
+++ b/polyfills/Object/fromEntries/tests.js
@@ -18,23 +18,23 @@ it('is not enumerable', function () {
 });
 
 it('throws when an entry object is a primitive string', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Object.fromEntries(['ab']);
     }, TypeError);
 });
 
 it('throws when an entry object is a undefined', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Object.fromEntries(undefined);
     }, TypeError);
 });
 it('throws when an entry object is null', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Object.fromEntries(null);
     }, TypeError);
 });
 it('throws when an entry object is absent', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Object.fromEntries();
     }, TypeError);
 });
@@ -53,17 +53,17 @@ if('Symbol' in this && 'iterator' in this.Symbol && !!Array.prototype[Symbol.ite
                 value: 'value',
                 enumerable: true,
                 writable: true,
-                configurable: true,
+                configurable: true
             });
         });
     }
     
     it('succeeds when an entry object is a boxed Object', function () {
-        proclaim.deepStrictEqual(Object.fromEntries([Object('ab')])['a'], 'b');
+        proclaim.deepStrictEqual(Object.fromEntries([Object('ab')]).a, 'b');
     });
     
     it('succeeds when an entry object is a boxed String', function () {
-        proclaim.deepStrictEqual(Object.fromEntries([new String('ab')])['a'], 'b');
+        proclaim.deepStrictEqual(Object.fromEntries([new String('ab')]).a, 'b');
     });
     it('works with Symbols', function () {
         var key = Symbol();

--- a/polyfills/Object/getOwnPropertyDescriptors/tests.js
+++ b/polyfills/Object/getOwnPropertyDescriptors/tests.js
@@ -18,11 +18,11 @@ it('is not enumerable', function () {
 });
 
 it('throws on invalid object', function() {
-  proclaim.throws(function () {
+  proclaim["throws"](function () {
     Object.getOwnPropertyDescriptors(null);
   }, TypeError, 'null is not an object');
 
-  proclaim.throws(function () {
+  proclaim["throws"](function () {
     Object.getOwnPropertyDescriptors(undefined);
   }, TypeError, 'undefined is not an object');
 });
@@ -66,6 +66,6 @@ it('works as expected', function () {
     value: 2,
     enumerable: false,
     writable: false,
-    configurable: false,
+    configurable: false
   });
 });

--- a/polyfills/Object/getOwnPropertyNames/tests.js
+++ b/polyfills/Object/getOwnPropertyNames/tests.js
@@ -35,10 +35,10 @@ it('does not include properties inherited from a prototype', function () {
 });
 
 it('throws an error when the arg is undefined or null', function() {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.getOwnPropertyNames(undefined);
 	});
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		Object.getOwnPropertyNames(null);
 	});
 });

--- a/polyfills/Object/keys/tests.js
+++ b/polyfills/Object/keys/tests.js
@@ -37,7 +37,7 @@ it('works as expected', function () {
     }
     for (i$ = 0, len$ = (ref$ = [null, void 8]).length; i$ < len$; ++i$) {
       value = ref$[i$];
-      proclaim.throws(fn1$, TypeError, "throws on " + value);
+      proclaim["throws"](fn1$, TypeError, "throws on " + value);
     }
     function fn$(){
       try {
@@ -85,13 +85,13 @@ it('works with objects containing otherwise non-enumerable keys', function () {
 });
 
 it('throws on empty, undefined, or null arguments', function () {
-  proclaim.throws(function () {
+  proclaim["throws"](function () {
     Object.keys();
   });
-  proclaim.throws(function () {
+  proclaim["throws"](function () {
     Object.keys(null);
   });
-  proclaim.throws(function () {
+  proclaim["throws"](function () {
     Object.keys(undefined);
   });
 });

--- a/polyfills/Reflect/apply/tests.js
+++ b/polyfills/Reflect/apply/tests.js
@@ -18,45 +18,45 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if `target` is not callable', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply('');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply(9);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply({});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply([]);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply(/./);
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.apply(Symbol());
         }, TypeError);
 
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.apply(Symbol('a'));
         }, TypeError);
     }
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply(true);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply(Number(9));
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply(new Number(9));
     }, TypeError);
 });
@@ -81,7 +81,7 @@ it('spreads third argument as the `arguments` for the `target` function', functi
 });
 
 it('throws a TypeError if third argument is not ArrayLike', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.apply(function () {}, 1, 1);
     }, TypeError);
 });

--- a/polyfills/Reflect/construct/tests.js
+++ b/polyfills/Reflect/construct/tests.js
@@ -18,27 +18,27 @@ it('is not enumerable', function () {
 });
 
 it('throws TypeError if `newTarget` is not a constuctor', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, [], 1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, [], null);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, [], {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, [], Math.sin);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, [], 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, [], /./);
     }, TypeError);
 });
@@ -55,27 +55,27 @@ it('if `newTarget` is absent, let `newTarget` be `target`', function () {
 });
 
 it('throws TypeError is `target` is not a constructor', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(1, []);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(null, []);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct({}, []);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(Math.sin, []);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct('a', []);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(/./, []);
     }, TypeError);
 });
@@ -87,7 +87,7 @@ it('spreads `argumentsList` as the arguments for the `target` constructor', func
 });
 
 it('throws TypeError is `argumentsList` is not ArrayLike', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.construct(function () {}, 9);
     }, TypeError);
 });

--- a/polyfills/Reflect/defineProperty/tests.js
+++ b/polyfills/Reflect/defineProperty/tests.js
@@ -34,24 +34,24 @@ if ('freeze' in Object) {
 }
 
 it('throws a TypeError if target is not an Object.', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.defineProperty(1, 'a', {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.defineProperty(null, 'a', {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.defineProperty(undefined, 'a', {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.defineProperty('', 'a', {});
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             Reflect.defineProperty(Symbol(), 'a', {});
         }, TypeError);
     }

--- a/polyfills/Reflect/deleteProperty/tests.js
+++ b/polyfills/Reflect/deleteProperty/tests.js
@@ -57,24 +57,24 @@ if ('freeze' in Object) {
 }
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.deleteProperty(1, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.deleteProperty(null, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.deleteProperty(undefined, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.deleteProperty('', 'a');
     }, TypeError);
     
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.deleteProperty(Symbol(), 'a');
         }, TypeError);
     }

--- a/polyfills/Reflect/get/tests.js
+++ b/polyfills/Reflect/get/tests.js
@@ -18,24 +18,24 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.get(1, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.get(null, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.get(undefined, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.get('', 'a');
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.get(Symbol(), 'a');
         }, TypeError);
     }

--- a/polyfills/Reflect/getOwnPropertyDescriptor/tests.js
+++ b/polyfills/Reflect/getOwnPropertyDescriptor/tests.js
@@ -18,24 +18,24 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if target is not an Object',function(){
-    proclaim.throws(function() {
+    proclaim["throws"](function() {
         Reflect.getOwnPropertyDescriptor(1, 'a');
     }, TypeError);
       
-    proclaim.throws(function() {
+    proclaim["throws"](function() {
         Reflect.getOwnPropertyDescriptor(null, 'a');
     }, TypeError);
       
-    proclaim.throws(function() {
+    proclaim["throws"](function() {
         Reflect.getOwnPropertyDescriptor(undefined, 'a');
     }, TypeError);
       
-    proclaim.throws(function() {
+    proclaim["throws"](function() {
         Reflect.getOwnPropertyDescriptor('', 'a');
     }, TypeError);
       
     if('Symbol' in this) {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             Reflect.getOwnPropertyDescriptor(Symbol(), 'a');
         }, TypeError);
     }

--- a/polyfills/Reflect/getPrototypeOf/tests.js
+++ b/polyfills/Reflect/getPrototypeOf/tests.js
@@ -30,24 +30,24 @@ it('returns the internal [[Prototype]] of an object', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.getPrototypeOf(1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.getPrototypeOf(null);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.getPrototypeOf(undefined);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.getPrototypeOf('');
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.getPrototypeOf(Symbol());
         }, TypeError);
     }

--- a/polyfills/Reflect/has/tests.js
+++ b/polyfills/Reflect/has/tests.js
@@ -35,24 +35,24 @@ it('returns false if the property is not anywhere in the prototype chain', funct
 });
 
 it('throws a TypeError if `target` is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.has(1, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.has(null, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.has(undefined, 'a');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.has('', 'a');
     }, TypeError);
 
     if('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.has(Symbol(), 'a');
         }, TypeError);
     }

--- a/polyfills/Reflect/isExtensible/tests.js
+++ b/polyfills/Reflect/isExtensible/tests.js
@@ -30,24 +30,24 @@ if ('preventExtensions' in Object) {
 }
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible(1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible(null);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible(undefined);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible('');
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.isExtensible(Symbol());
         }, TypeError);
     }

--- a/polyfills/Reflect/ownKeys/tests.js
+++ b/polyfills/Reflect/ownKeys/tests.js
@@ -27,24 +27,24 @@ it('returns an empty array if target has no own properties', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.ownKeys(1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.ownKeys(null);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.ownKeys(undefined);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.ownKeys('');
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.ownKeys(Symbol());
         }, TypeError);
     }

--- a/polyfills/Reflect/preventExtensions/tests.js
+++ b/polyfills/Reflect/preventExtensions/tests.js
@@ -36,24 +36,24 @@ if ('isExtensible' in Object) {
 }
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible(1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible(null);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible(undefined);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.isExtensible('');
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.isExtensible(Symbol());
         }, TypeError);
     }

--- a/polyfills/Reflect/set/tests.js
+++ b/polyfills/Reflect/set/tests.js
@@ -18,24 +18,24 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.set(1, 'a', 1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.set(null, 'a', 1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.set(undefined, 'a', 1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.set('', 'a', 1);
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.set(Symbol(), 'p', 42);
         }, TypeError);
     }

--- a/polyfills/Reflect/setPrototypeOf/tests.js
+++ b/polyfills/Reflect/setPrototypeOf/tests.js
@@ -18,19 +18,19 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if proto is not Object or proto is not null', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf({}, undefined);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf({}, 1);
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf({}, 'string');
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf({}, true);
     }, TypeError);
 });
@@ -54,24 +54,24 @@ if ('__proto__' in Object.prototype) {
     });
 }
 it('throws a TypeError if target is not an Object', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf(1, {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf(null, {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf(undefined, {});
     }, TypeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect.setPrototypeOf('', {});
     }, TypeError);
 
     if ('Symbol' in this) {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             Reflect.setPrototypeOf(Symbol(), {});
         }, TypeError);
     }

--- a/polyfills/Reflect/tests.js
+++ b/polyfills/Reflect/tests.js
@@ -16,10 +16,10 @@ if ('getPrototypeOf' in Object) {
 }
 
 it('cannot be called or constructed', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         Reflect();
     });
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         new Reflect;
     });
 });

--- a/polyfills/RegExp/prototype/flags/tests.js
+++ b/polyfills/RegExp/prototype/flags/tests.js
@@ -61,7 +61,7 @@ if (supportsDescriptors) {
 	ifCallAllowsPrimitivesIt('throws when not called on an object', function () {
 		var nonObjects = ['', false, true, 42, NaN, null, undefined];
 		nonObjects.forEach(function (nonObject) {
-			proclaim.throws(function () {
+			proclaim["throws"](function () {
 				testGenericRegExpFlags(nonObject);
 			}, TypeError);
 		});

--- a/polyfills/Set/polyfill.js
+++ b/polyfills/Set/polyfill.js
@@ -485,7 +485,7 @@
 	} catch (e) {
 		// IE8 throws an error here if we set enumerable to false.
 		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global['Set'] = Set;
+		global.Set = Set;
 	}
 
 }(this));

--- a/polyfills/Set/tests.js
+++ b/polyfills/Set/tests.js
@@ -258,7 +258,7 @@ describe('Set', function() {
 		});
 
 		it("throws for non-iterable arguments", function() {
-			proclaim.throws(function() {
+			proclaim["throws"](function() {
 				new Set(1);
 			}, TypeError);
 		});

--- a/polyfills/String/fromCodePoint/tests.js
+++ b/polyfills/String/fromCodePoint/tests.js
@@ -30,43 +30,43 @@ it('works as expected', function () {
 	proclaim.strictEqual(String.fromCodePoint(0x61, 0x62, 0x1D307), 'ab\uD834\uDF07');
 	proclaim.strictEqual(String.fromCodePoint(false), '\0');
 	proclaim.strictEqual(String.fromCodePoint(null), '\0');
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint('_');
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint('+Infinity');
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint('-Infinity');
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(-1);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(0x10FFFF + 1);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(3.14);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(3e-2);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(-Infinity);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(Infinity);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(NaN);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(undefined);
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint({});
 	}, RangeError);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		String.fromCodePoint(/./);
 	}, RangeError);
 	var tmp = 0x60;

--- a/polyfills/String/prototype/anchor/tests.js
+++ b/polyfills/String/prototype/anchor/tests.js
@@ -23,13 +23,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.anchor.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.anchor.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/big/tests.js
+++ b/polyfills/String/prototype/big/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.big.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.big.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/blink/tests.js
+++ b/polyfills/String/prototype/blink/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.blink.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.blink.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/bold/tests.js
+++ b/polyfills/String/prototype/bold/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.bold.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.bold.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/codePointAt/tests.js
+++ b/polyfills/String/prototype/codePointAt/tests.js
@@ -55,19 +55,19 @@ describe('#codePointAt()', function () {
 	});
 
 	ifHasStrictModeIt('should throw a TypeError when called on null or undefined', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.codePointAt.call(undefined);
 		}, TypeError);
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.codePointAt.call(null);
 		}, TypeError);
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.codePointAt.apply(undefined);
 		}, TypeError);
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.codePointAt.apply(null);
 		}, TypeError);
 	});
@@ -147,10 +147,10 @@ it('works as expected', function () {
 	proclaim.strictEqual('\uDF06abc'.codePointAt(null), 0xDF06);
 	proclaim.strictEqual('\uDF06abc'.codePointAt(undefined), 0xDF06);
 	if (hasStrictMode) {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.codePointAt.call(null, 0);
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.codePointAt.call(undefined, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/endsWith/tests.js
+++ b/polyfills/String/prototype/endsWith/tests.js
@@ -46,15 +46,15 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.endsWith.call(null, '.');
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.endsWith.call(undefined, '.');
 		}, TypeError);
 	}
 	re = /./;
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		'/./'.endsWith(re);
 	}, TypeError);
 	if ('Symbol' in window && 'match' in Symbol) {
@@ -65,7 +65,7 @@ it('works as expected', function () {
 	proclaim.isTrue('[object Object]'.endsWith(O));
 	if ('Symbol' in window && 'match' in Symbol) {
 		O[typeof Symbol != 'undefined' && Symbol !== null ? Symbol.match : undefined] = true;
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			'[object Object]'.endsWith(O);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/fixed/tests.js
+++ b/polyfills/String/prototype/fixed/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.fixed.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.fixed.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/fontcolor/tests.js
+++ b/polyfills/String/prototype/fontcolor/tests.js
@@ -25,13 +25,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.fontcolor.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.fontcolor.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/fontsize/tests.js
+++ b/polyfills/String/prototype/fontsize/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.fontsize.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.fontsize.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/includes/tests.js
+++ b/polyfills/String/prototype/includes/tests.js
@@ -30,15 +30,15 @@ it('works as expected', function(){
 		}).call(undefined);
 
 		if (supportsStrictModeTests) {
-      proclaim.throws(function(){
+      proclaim["throws"](function(){
         String.prototype.includes.call(null, '.');
       }, TypeError);
-      proclaim.throws(function(){
+      proclaim["throws"](function(){
         String.prototype.includes.call(undefined, '.');
       }, TypeError);
     }
     re = /./;
-    proclaim.throws(function(){
+    proclaim["throws"](function(){
       '/./'.includes(re);
 		}, TypeError);
 	if ('Symbol' in window && 'match' in Symbol) {
@@ -49,7 +49,7 @@ it('works as expected', function(){
     proclaim.isTrue('[object Object]'.includes(O));
 	if ('Symbol' in window && 'match' in Symbol) {
 		O[typeof Symbol != 'undefined' && Symbol !== null ? Symbol.match : undefined] = true;
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			'[object Object]'.includes(O);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/italics/tests.js
+++ b/polyfills/String/prototype/italics/tests.js
@@ -23,13 +23,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.italics.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.italics.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/link/tests.js
+++ b/polyfills/String/prototype/link/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.link.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.link.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/normalize/tests.js
+++ b/polyfills/String/prototype/normalize/tests.js
@@ -18,15 +18,15 @@ it('is not enumerable', function () {
 });
 
 it('throws a RangeError if ToString(form) value is not a valid form name', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         'a'.normalize('b');
     }, RangeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         'a'.normalize('NFC1');
     }, RangeError);
 
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         'a'.normalize(null);
     }, RangeError);
 });
@@ -82,13 +82,13 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
     it('throws TypeError if `this` is null', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             String.prototype.normalize.call(null);
         }, TypeError);
     });
 
     it('throws TypeError if `this` is undefined', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             String.prototype.normalize.call(undefined);
         }, TypeError);
     });

--- a/polyfills/String/prototype/padEnd/tests.js
+++ b/polyfills/String/prototype/padEnd/tests.js
@@ -40,10 +40,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.padEnd.call(null, 0);
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.padEnd.call(undefined, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/padStart/tests.js
+++ b/polyfills/String/prototype/padStart/tests.js
@@ -39,10 +39,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim.throws(function(){
+		proclaim["throws"](function(){
 			String.prototype.padStart.call(null, 0);
 		}, TypeError);
-		proclaim.throws(function(){
+		proclaim["throws"](function(){
 			String.prototype.padStart.call(undefined, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/repeat/tests.js
+++ b/polyfills/String/prototype/repeat/tests.js
@@ -35,15 +35,15 @@ it('works with strings', function () {
 });
 
 it('throws invalid counts', function () {
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		'abc'.repeat(-Infinity);
 	}, RangeError);
 
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		'abc'.repeat(-1);
 	}, RangeError);
 
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		'abc'.repeat(+Infinity);
 	}, RangeError);
 });
@@ -74,35 +74,35 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('throws incoercible objects', function () {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.call(undefined);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.call(undefined, 4);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.call(null);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.call(null, 4);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.apply(undefined);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.apply(undefined, [4]);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.apply(null);
 		});
 
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.repeat.apply(null, [4]);
 		});
 	});

--- a/polyfills/String/prototype/small/tests.js
+++ b/polyfills/String/prototype/small/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.small.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.small.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/startsWith/tests.js
+++ b/polyfills/String/prototype/startsWith/tests.js
@@ -37,14 +37,14 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.startsWith.call(null, '.');
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.startsWith.call(undefined, '.');
 		}, TypeError);
 	}
-	proclaim.throws(function(){
+	proclaim["throws"](function(){
 		'/./'.startsWith(/./);
 	}, TypeError);
 	proclaim.isTrue('[object Object]'.startsWith({}));

--- a/polyfills/String/prototype/strike/tests.js
+++ b/polyfills/String/prototype/strike/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.strike.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.strike.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/sub/tests.js
+++ b/polyfills/String/prototype/sub/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.sub.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.sub.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/sup/tests.js
+++ b/polyfills/String/prototype/sup/tests.js
@@ -24,13 +24,13 @@ it('is not enumerable', function () {
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with undefined context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.sup.call(undefined);
     }, TypeError);
 });
 
 ifHasStrictModeIt('should throw a TypeError when called with null context', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.prototype.sup.call(null);
     }, TypeError);
 });

--- a/polyfills/String/prototype/trim/tests.js
+++ b/polyfills/String/prototype/trim/tests.js
@@ -29,10 +29,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.trim.call(null, 0);
 		}, TypeError);
-		proclaim.throws(function () {
+		proclaim["throws"](function () {
 			String.prototype.trim.call(void 8, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/raw/tests.js
+++ b/polyfills/String/raw/tests.js
@@ -19,7 +19,7 @@ it('is not enumerable', function () {
 
 if ('Symbol' in self) {
     it('throws a TypeError if nextKey is a Symbol', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             String.raw({
                 raw: {
                     length: 1,
@@ -32,7 +32,7 @@ if ('Symbol' in self) {
 
 if ('Symbol' in self) {
     it('throws a TypeError if length is a Symbol', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             String.raw({
                 raw: {
                     length: Symbol()
@@ -43,7 +43,7 @@ if ('Symbol' in self) {
 }
 
 it('calls the toString method on the keys', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.raw({
             raw: {
                 length: 1,
@@ -59,13 +59,13 @@ it('calls the toString method on the keys', function () {
 
 if ('Symbol' in self) {
     it('throws a TypeError if a Symbol is used as a substitution', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             String.raw({
                 raw: ['a', 'b', 'c']
             }, '', Symbol(''));
         }, TypeError);
 
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             String.raw({
                 raw: ['a', 'b', 'c']
             }, Symbol(''), '');
@@ -149,19 +149,19 @@ it('returns empty string if template.raw.length is less than 1.', function () {
 });
 
 it('throws a TypeError if called with null', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.raw(null);
     });
 });
 
 it('throws a TypeError if called with undefined', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.raw(undefined);
     });
 });
 
 it('throws a TypeError if called with raw as null', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.raw({
             raw: null
         });
@@ -169,7 +169,7 @@ it('throws a TypeError if called with raw as null', function () {
 });
 
 it('throws a TypeError if called with raw as undefined', function () {
-    proclaim.throws(function () {
+    proclaim["throws"](function () {
         String.raw({
             raw: undefined
         });

--- a/polyfills/Symbol/prototype/description/tests.js
+++ b/polyfills/Symbol/prototype/description/tests.js
@@ -71,55 +71,55 @@ if (Object.getOwnPropertyDescriptor) {
     });
 
     it('throws an error if context is a number', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call(1);
         }, TypeError);
     });
     
     it('throws an error if context is null', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call(null);
         }, TypeError);
     });
     
     it('throws an error if context is undefined', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call(undefined);
         }, TypeError);
     });
     
     it('throws an error if context is an array', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call([]);
         }, TypeError);
     });
     
     it('throws an error if context is an object', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call({});
         }, TypeError);
     });
     
     it('throws an error if context is a regex', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call(/./);
         }, TypeError);
     });
     
     it('throws an error if context is NaN', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call(NaN);
         }, TypeError);
     });
     
     it('throws an error if context is a function', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call(function(){});
         }, TypeError);
     });
 
     it('throws an error if context is a string', function () {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             getter.call('kate');
         }, TypeError);
     });

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -37,7 +37,7 @@ it('should throw if being used via `new`', function() {
 	var test = function () {
 		return new Symbol();
 	};
-	proclaim.throws(test);
+	proclaim["throws"](test);
 });
 
 it('should have Symbol as the constructor property', function() {
@@ -115,12 +115,12 @@ it('Symbol.keyFor should throw if not given a symbol', function() {
 		return Symbol.keyFor(Symbol("4"));
 	};
 
-	proclaim.throws(stringKeyFor);
-	proclaim.throws(numberKeyFor);
-	proclaim.throws(arrayKeyFor);
-	proclaim.throws(objectKeyFor);
-	proclaim.throws(boolKeyFor);
-	proclaim.throws(undefinedKeyFor);
+	proclaim["throws"](stringKeyFor);
+	proclaim["throws"](numberKeyFor);
+	proclaim["throws"](arrayKeyFor);
+	proclaim["throws"](objectKeyFor);
+	proclaim["throws"](boolKeyFor);
+	proclaim["throws"](undefinedKeyFor);
 	proclaim.doesNotThrow(symbolKeyFor);
 });
 
@@ -151,8 +151,8 @@ it('Symbol.keyFor should return key of symbol if can find symbol in global regis
 });
 
 it('has toString and valueOf instance methods', function() {
-	proclaim.isInstanceOf(Symbol.prototype['toString'], Function);
-	proclaim.isInstanceOf(Symbol.prototype['valueOf'], Function);
+	proclaim.isInstanceOf(Symbol.prototype.toString, Function);
+	proclaim.isInstanceOf(Symbol.prototype.valueOf, Function);
 });
 
 if (supportsDescriptors) {
@@ -211,7 +211,7 @@ xit('should not allow implicit string coercion', function() {
 	var implicitStringCoercion = function() {
 		return Symbol('10') + '';
 	};
-	proclaim.throws(implicitStringCoercion);
+	proclaim["throws"](implicitStringCoercion);
 });
 
 it('should create Object without symbols', function () {

--- a/polyfills/URL/polyfill.js
+++ b/polyfills/URL/polyfill.js
@@ -260,7 +260,7 @@
 
     function Iterator(source, kind) {
       var index = 0;
-      this['next'] = function() {
+      this.next = function() {
         if (index >= source.length)
           return {done: true, value: undefined};
         var pair = source[index++];
@@ -338,7 +338,7 @@
         if (!('defineProperties' in Object)) return false;
         try {
           var obj = {};
-          Object.defineProperties(obj, { prop: { 'get': function () { return true; } } });
+          Object.defineProperties(obj, { prop: { get: function () { return true; } } });
           return obj.prop;
         } catch (_) {
           return false;

--- a/polyfills/UserTiming/tests.js
+++ b/polyfills/UserTiming/tests.js
@@ -20,7 +20,7 @@ describe("mark()", function() {
     });
 
     it("should throw an exception when a null argument is given", function() {
-        proclaim.throws(perf.mark);
+        proclaim["throws"](perf.mark);
     });
 
     it("should throw an exception when passing in a NavigationTiming mark", function() {
@@ -29,7 +29,7 @@ describe("mark()", function() {
             typeof window.performance !== "undefined" &&
             typeof window.performance.timing !== "undefined" &&
             window.performance.timing.navigationStart) {
-            proclaim.throws(function() {
+            proclaim["throws"](function() {
                 perf.mark("navigationStart");
             });
         }
@@ -287,22 +287,22 @@ describe("measure()", function() {
     });
 
     it("should throw an error if not given a name", function() {
-        proclaim.throws(perf.measure);
+        proclaim["throws"](perf.measure);
     });
 
     it("should throw an error if not given a name", function() {
-        proclaim.throws(perf.measure);
+        proclaim["throws"](perf.measure);
     });
 
     it("should throw an exception if the start mark name is not found", function() {
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             perf.measure("foo", "BAD_MARK!");
         }, Error);
     });
 
     it("should throw an exception if the end mark name is not found", function() {
         perf.mark("1");
-        proclaim.throws(function() {
+        proclaim["throws"](function() {
             perf.measure("foo", "1", "BAD_MARK!");
         }, Error);
     });

--- a/polyfills/WeakMap/polyfill.js
+++ b/polyfills/WeakMap/polyfill.js
@@ -258,6 +258,6 @@
 	} catch (e) {
 		// IE8 throws an error here if we set enumerable to false.
 		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global['WeakMap'] = WeakMap;
+		global.WeakMap = WeakMap;
 	}
 }(this));

--- a/polyfills/WeakMap/tests.js
+++ b/polyfills/WeakMap/tests.js
@@ -27,16 +27,16 @@ it("has valid constructor", function () {
 		proclaim.equal((new WeakMap).__proto__ === WeakMap.prototype, true);
 	}
 
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		WeakMap();
 	}, TypeError);
 });
 
 it('has get, set, delete, and has functions', function() {
-	proclaim.isFunction(WeakMap.prototype['get']);
-	proclaim.isFunction(WeakMap.prototype['set']);
+	proclaim.isFunction(WeakMap.prototype.get);
+	proclaim.isFunction(WeakMap.prototype.set);
 	proclaim.isFunction(WeakMap.prototype['delete']);
-	proclaim.isFunction(WeakMap.prototype['has']);
+	proclaim.isFunction(WeakMap.prototype.has);
 });
 it('should perform as expected', function() {
 	var wm = new WeakMap();
@@ -171,7 +171,7 @@ it('WeakMap.prototype.set', function () {
 	proclaim.isNotEnumerable(WeakMap.prototype, 'set');
 	wmap.set(a, 42);
 	proclaim.strictEqual(wmap.get(a), 42);
-	proclaim.throws(function () {
+	proclaim["throws"](function () {
 		new WeakMap().set(42, 42);
 	}, TypeError);
 	proclaim.deepEqual(wmap.set({}, 1), wmap);

--- a/polyfills/WeakSet/polyfill.js
+++ b/polyfills/WeakSet/polyfill.js
@@ -197,7 +197,7 @@
 	} catch (e) {
 		// IE8 throws an error here if we set enumerable to false.
 		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global['WeakSet'] = WeakSet;
+		global.WeakSet = WeakSet;
 	}
 
 }(this));

--- a/polyfills/WeakSet/tests.js
+++ b/polyfills/WeakSet/tests.js
@@ -37,9 +37,9 @@ it('should be instantiable', function(){
 });
 
 it('has add, delete and has methods', function(){
-	proclaim.notEqual(WeakSet.prototype['add'], undefined);
+	proclaim.notEqual(WeakSet.prototype.add, undefined);
 	proclaim.notEqual(WeakSet.prototype['delete'], undefined);
-	proclaim.notEqual(WeakSet.prototype['has'], undefined);
+	proclaim.notEqual(WeakSet.prototype.has, undefined);
 });
 
 it('should perform as expected', function() {

--- a/polyfills/_ESAbstract/AddEntriesFromIterable/polyfill.js
+++ b/polyfills/_ESAbstract/AddEntriesFromIterable/polyfill.js
@@ -30,6 +30,7 @@ function AddEntriesFromIterable(target, iterable, adder) { // eslint-disable-lin
         try {
             // e. Let k be Get(nextItem, "0").
             k = Get(nextItem, "0");
+        // eslint-disable-next-line no-catch-shadow
         } catch (k) {
             // f. If k is an abrupt completion, return ? IteratorClose(iteratorRecord, k).
             return IteratorClose(iteratorRecord, k);
@@ -38,6 +39,7 @@ function AddEntriesFromIterable(target, iterable, adder) { // eslint-disable-lin
         try {
             // g. Let v be Get(nextItem, "1").
             v = Get(nextItem, "1");
+        // eslint-disable-next-line no-catch-shadow
         } catch (v) {
             // h. If v is an abrupt completion, return ? IteratorClose(iteratorRecord, v).
             return IteratorClose(iteratorRecord, v);
@@ -45,6 +47,7 @@ function AddEntriesFromIterable(target, iterable, adder) { // eslint-disable-lin
         try {
             // i. Let status be Call(adder, target, « k.[[Value]], v.[[Value]] »).
             Call(adder, target, [k, v]);
+        // eslint-disable-next-line no-catch-shadow
         } catch (status) {
             // j. If status is an abrupt completion, return ? IteratorClose(iteratorRecord, status).
             return IteratorClose(iteratorRecord, status);

--- a/polyfills/atob/tests.js
+++ b/polyfills/atob/tests.js
@@ -3,21 +3,21 @@
 
 // Doesn't throw in IE6, otherwise works fine, so tolerate this
 it.skip("should throw exception for invalid characters in code", function () {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3$VyZ");
 	});
 });
 
 // Doesn't throw in IE6, otherwise works fine, so tolerate this
 it.skip("should throw exception for too much padding", function () {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3VyZ===");
 	});
 });
 
 // Not supported by the polyfill, probably not a problem
 it.skip("should throw exception for badly formed base64", function () {
-	proclaim.throws(function() {
+	proclaim["throws"](function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3VyZ");
 	});
 });

--- a/polyfills/getComputedStyle/polyfill.js
+++ b/polyfills/getComputedStyle/polyfill.js
@@ -53,7 +53,7 @@
 			} else if (property == 'height') {
 				style[property] = element.offsetHeight + 'px';
 			} else if (property == 'styleFloat') {
-				style.float = currentStyle[property];
+				style["float"] = currentStyle[property];
 			} else if (/margin.|padding.|border.+W/.test(property) && style[property] != 'auto') {
 				style[property] = Math.round(getComputedStylePixel(element, property, fontSize)) + 'px';
 			} else if (/^outline/.test(property)) {

--- a/polyfills/requestIdleCallback/tests.js
+++ b/polyfills/requestIdleCallback/tests.js
@@ -8,7 +8,7 @@ describe('IdleDeadline', function () {
     });
 
     it('throws a type type error when used as a constructor', function () {
-        proclaim.throws(function () {
+        proclaim["throws"](function () {
             new IdleDeadline();
         }, TypeError);
     });
@@ -17,7 +17,7 @@ describe('IdleDeadline', function () {
     // error, except where getters aren't supported return undefined.
     it('has a didTimeout prototype property which throws a type error when getters are supported or undefined otherwise', function () {
         if (Object.prototype.hasOwnProperty('__defineGetter__')) {
-            proclaim.throws(function () {
+            proclaim["throws"](function () {
                 return IdleDeadline.prototype.didTimeout;
             }, TypeError);
         } else {
@@ -27,7 +27,7 @@ describe('IdleDeadline', function () {
 
     it('has a timeRemaining prototype function which throws a type error', function () {
         proclaim.isTypeOf(IdleDeadline.prototype.timeRemaining, 'function');
-        proclaim.throws(IdleDeadline.prototype.timeRemaining, TypeError);
+        proclaim["throws"](IdleDeadline.prototype.timeRemaining, TypeError);
     });
 
 });
@@ -313,7 +313,7 @@ describe('cancelIdleCallback', function () {
     });
 
     it('should throw a type error if given no arguments', function () {
-        proclaim.throws(cancelIdleCallback, TypeError);
+        proclaim["throws"](cancelIdleCallback, TypeError);
     });
 
     it('cancels an idle callback', function (done) {

--- a/polyfills/~viewport/polyfill.js
+++ b/polyfills/~viewport/polyfill.js
@@ -20,26 +20,26 @@
 
 	try {
 		Object.defineProperties(global, {
-			'innerWidth': {
+			innerWidth: {
 				get: function () {
 					return docEl.clientWidth;
 				}
 			},
-			'innerHeight': {
+			innerHeight: {
 				get: function () {
 					return docEl.clientHeight;
 				}
 			},
-			'pageXOffset': {
+			pageXOffset: {
 				get: scrollX
 			},
-			'pageYOffset': {
+			pageYOffset: {
 				get: scrollY
 			},
-			'scrollX': {
+			scrollX: {
 				get: scrollX
 			},
-			'scrollY': {
+			scrollY: {
 				get: scrollY
 			}
 		});


### PR DESCRIPTION
This avoids potential bugs slipping in such as usinng keywords in dot-notation, which causes Internet Explorer 8 to throw an error during the parsing of the JavaScript.