### PR TITLE
prevent focusin detection from scrolling

### DIFF
--- a/polyfills/Event/focusin/detect.js
+++ b/polyfills/Event/focusin/detect.js
@@ -17,6 +17,7 @@
 	}
 
 	a.href = '#';
+	a.style='position: fixed';
 
 	if ('addEventListener' in a) {
 		a.addEventListener('focusin', onfocusin);


### PR DESCRIPTION
in order to prevent focusin from accidentally scrolling chrome, setting it a `position:fixed` does the trick. Yet, as this is not widely used and impacts fewer browsers, I would rather like to removing this from default polyfill and give to the developer the liberty of having this detection run. Modifying the dom is always costly!