### PR TITLE
do not serve copywithin polyfill to edge 12 or above

### DIFF
--- a/polyfills/Array/prototype/copyWithin/config.toml
+++ b/polyfills/Array/prototype/copyWithin/config.toml
@@ -9,8 +9,8 @@ spec = "https://tc39.github.io/ecma262/#sec-array.prototype.copywithin"
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin"
 
 [browsers]
-edge = "*"
-edge_mob = "*"
+edge = "<12"
+edge_mob = "<12"
 chrome = "<45"
 firefox = "<32"
 ie = "*"


### PR DESCRIPTION
browser support taken from MDN -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin#Browser_compatibility