### PR TITLE
Add es2019 alias for all the new features which were added to the spec in that version

### DIFF
--- a/polyfills/Array/prototype/flat/config.toml
+++ b/polyfills/Array/prototype/flat/config.toml
@@ -1,3 +1,6 @@
+alias = [
+  "es2019"
+]
 dependencies = [
   "_ESAbstract.CreateMethodProperty",
   "_ESAbstract.ToObject",

--- a/polyfills/Array/prototype/flatMap/config.toml
+++ b/polyfills/Array/prototype/flatMap/config.toml
@@ -1,3 +1,6 @@
+alias = [
+  "es2019"
+]
 dependencies = [
   "_ESAbstract.CreateMethodProperty",
   "_ESAbstract.ToObject",

--- a/polyfills/Object/fromEntries/config.toml
+++ b/polyfills/Object/fromEntries/config.toml
@@ -1,4 +1,4 @@
-aliases = [ ]
+aliases = ["es2019"]
 dependencies = [
   "_ESAbstract.CreateMethodProperty",
   "_ESAbstract.RequireObjectCoercible",
@@ -26,4 +26,3 @@ op_mob = "*"
 opera = "*"
 safari = "<12.1"
 samsung_mob = "*"
-

--- a/polyfills/String/prototype/trimEnd/config.toml
+++ b/polyfills/String/prototype/trimEnd/config.toml
@@ -1,4 +1,4 @@
-aliases = [ ]
+aliases = [ "es2019" ]
 dependencies = [ "_ESAbstract.CreateMethodProperty", "_ESAbstract.TrimString" ]
 spec = "https://tc39.github.io/ecma262/#sec-string.prototype.trimend"
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd"

--- a/polyfills/String/prototype/trimStart/config.toml
+++ b/polyfills/String/prototype/trimStart/config.toml
@@ -1,4 +1,4 @@
-aliases = [ ]
+aliases = [ "es2019" ]
 dependencies = [ "_ESAbstract.CreateMethodProperty", "_ESAbstract.TrimString" ]
 spec = "https://tc39.github.io/ecma262/#sec-string.prototype.trimstart"
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart"


### PR DESCRIPTION
ECMAScript 2019 introduced a few new built-in functions: flat and flatMap on Array.prototype for flattening arrays, Object.fromEntries for directly turning the return value of Object.entries into a new Object, and trimStart and trimEnd on String.prototype as better-named alternatives to the widely implemented but non-standard String.prototype.trimLeft and trimRight built-ins.

fixes https://github.com/Financial-Times/polyfill-library/issues/329