### PR TITLE
Add nextElementSibling and previousElementSibling polyfills

### DIFF
--- a/polyfills/Element/prototype/nextElementSibling/config.toml
+++ b/polyfills/Element/prototype/nextElementSibling/config.toml
@@ -1,0 +1,25 @@
+aliases = [ ]
+dependencies = [
+  "Element",
+  "Object.defineProperty"
+]
+license = "MIT"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling"
+
+[browsers]
+# android = "all versions natively support this feature"
+# bb = "Not on MDN"
+chrome = "<4"
+edge = "<12"
+# edge_mob = "Not on MDN"
+firefox = "<3.5"
+# ios_chr = "Not on MDN"
+# ios_saf = "all versions natively support this feature"
+ie = "<9"
+# ie_mob = "Not on MDN"
+opera = "<10"
+# op_mini = "Not on MDN"
+op_mob = "<10.1"
+safari = "<4"
+firefox_mob = "<4"
+# samsung_mob = "all versions natively support this feature"

--- a/polyfills/Element/prototype/nextElementSibling/detect.js
+++ b/polyfills/Element/prototype/nextElementSibling/detect.js
@@ -1,0 +1,1 @@
+'document' in self && "nextElementSibling" in document.documentElement

--- a/polyfills/Element/prototype/nextElementSibling/polyfill.js
+++ b/polyfills/Element/prototype/nextElementSibling/polyfill.js
@@ -1,0 +1,7 @@
+Object.defineProperty(Element.prototype, "nextElementSibling", {
+	get: function(){
+		var el = this.nextSibling;
+		while (el && el.nodeType !== 1) { el = el.nextSibling; }
+		return el;
+	}
+});

--- a/polyfills/Element/prototype/nextElementSibling/tests.js
+++ b/polyfills/Element/prototype/nextElementSibling/tests.js
@@ -1,0 +1,45 @@
+it("should return null if the node is the only child of its parent node", function () {
+  var parent = document.createElement('div'),
+      p = document.createElement('p');
+  parent.appendChild(p);
+
+  proclaim.strictEqual(p.nextElementSibling, null);
+});
+
+it("should return null if the node only has text sibling", function () {
+  var parent = document.createElement('div'),
+      p = document.createElement('p');
+      text = document.createTextNode('Hi there, how are you doing today?');
+  parent.appendChild(p);
+  parent.appendChild(text);
+
+  proclaim.strictEqual(p.nextElementSibling, null);
+});
+
+it("should return null if the node only has comment sibling", function () {
+  var parent = document.createElement('div'),
+      p = document.createElement('p');
+      comment = document.createComment('This is a comment in the document.');
+  parent.appendChild(p);
+  parent.appendChild(comment);
+
+  proclaim.strictEqual(p.nextElementSibling, null);
+});
+
+it("should return the first child element", function () {
+  var parent = document.createElement('div'),
+      h2 = document.createElement('h2'),
+      p1 = document.createElement('p'),
+      p2 = document.createElement('p'),
+      p3 = document.createElement('p'),
+      text = document.createTextNode('Hi there, how are you doing today?'),
+      comment = document.createComment('This is a comment in the document.');
+  parent.appendChild(h2);
+  parent.appendChild(text);
+  parent.appendChild(comment);
+  parent.appendChild(p1);
+  parent.appendChild(p2);
+  parent.appendChild(p3);
+
+  proclaim.strictEqual(h2.nextElementSibling, p1);
+});

--- a/polyfills/Element/prototype/nextElementSibling/tests.js
+++ b/polyfills/Element/prototype/nextElementSibling/tests.js
@@ -1,3 +1,6 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
 it("should return null if the node is the only child of its parent node", function () {
   var parent = document.createElement('div'),
       p = document.createElement('p');
@@ -8,7 +11,7 @@ it("should return null if the node is the only child of its parent node", functi
 
 it("should return null if the node only has text sibling", function () {
   var parent = document.createElement('div'),
-      p = document.createElement('p');
+      p = document.createElement('p'),
       text = document.createTextNode('Hi there, how are you doing today?');
   parent.appendChild(p);
   parent.appendChild(text);
@@ -18,7 +21,7 @@ it("should return null if the node only has text sibling", function () {
 
 it("should return null if the node only has comment sibling", function () {
   var parent = document.createElement('div'),
-      p = document.createElement('p');
+      p = document.createElement('p'),
       comment = document.createComment('This is a comment in the document.');
   parent.appendChild(p);
   parent.appendChild(comment);

--- a/polyfills/Element/prototype/previousElementSibling/config.toml
+++ b/polyfills/Element/prototype/previousElementSibling/config.toml
@@ -1,0 +1,25 @@
+aliases = [ ]
+dependencies = [
+  "Element",
+  "Object.defineProperty"
+]
+license = "MIT"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/previousElementSibling"
+
+[browsers]
+# android = "all versions natively support this feature"
+# bb = "Not on MDN"
+chrome = "<4"
+edge = "<12"
+# edge_mob = "Not on MDN"
+firefox = "<3.5"
+# ios_chr = "Not on MDN"
+# ios_saf = "all versions natively support this feature"
+ie = "<9"
+# ie_mob = "Not on MDN"
+opera = "<10"
+# op_mini = "Not on MDN"
+op_mob = "<10.1"
+safari = "<4"
+firefox_mob = "<4"
+# samsung_mob = "all versions natively support this feature"

--- a/polyfills/Element/prototype/previousElementSibling/detect.js
+++ b/polyfills/Element/prototype/previousElementSibling/detect.js
@@ -1,0 +1,1 @@
+'document' in self && "previousElementSibling" in document.documentElement

--- a/polyfills/Element/prototype/previousElementSibling/polyfill.js
+++ b/polyfills/Element/prototype/previousElementSibling/polyfill.js
@@ -1,0 +1,7 @@
+Object.defineProperty(Element.prototype, 'previousElementSibling', {
+	get: function(){
+		var el = this.previousSibling;
+		while (el && el.nodeType !== 1) { el = el.previousSibling; }
+		return el;
+	}
+});

--- a/polyfills/Element/prototype/previousElementSibling/tests.js
+++ b/polyfills/Element/prototype/previousElementSibling/tests.js
@@ -1,0 +1,45 @@
+it("should return null if the node is the only child of its parent node", function () {
+  var parent = document.createElement('div'),
+      p = document.createElement('p');
+  parent.appendChild(p);
+
+  proclaim.strictEqual(p.nextElementSibling, null);
+});
+
+it("should return null if the node only has text sibling", function () {
+  var parent = document.createElement('div'),
+      p = document.createElement('p');
+      text = document.createTextNode('Hi there, how are you doing today?');
+  parent.appendChild(p);
+  parent.appendChild(text);
+
+  proclaim.strictEqual(p.nextElementSibling, null);
+});
+
+it("should return null if the node only has comment sibling", function () {
+  var parent = document.createElement('div'),
+      p = document.createElement('p');
+      comment = document.createComment('This is a comment in the document.');
+  parent.appendChild(p);
+  parent.appendChild(comment);
+
+  proclaim.strictEqual(p.nextElementSibling, null);
+});
+
+it("should return the first child element", function () {
+  var parent = document.createElement('div'),
+      h2 = document.createElement('h2'),
+      p1 = document.createElement('p'),
+      p2 = document.createElement('p'),
+      p3 = document.createElement('p'),
+      text = document.createTextNode('Hi there, how are you doing today?'),
+      comment = document.createComment('This is a comment in the document.');
+  parent.appendChild(h2);
+  parent.appendChild(text);
+  parent.appendChild(comment);
+  parent.appendChild(p1);
+  parent.appendChild(p2);
+  parent.appendChild(p3);
+
+  proclaim.strictEqual(h2.nextElementSibling, p1);
+});

--- a/polyfills/Element/prototype/previousElementSibling/tests.js
+++ b/polyfills/Element/prototype/previousElementSibling/tests.js
@@ -6,27 +6,27 @@ it("should return null if the node is the only child of its parent node", functi
       p = document.createElement('p');
   parent.appendChild(p);
 
-  proclaim.strictEqual(p.nextElementSibling, null);
+  proclaim.strictEqual(p.previousElementSibling, null);
 });
 
 it("should return null if the node only has text sibling", function () {
   var parent = document.createElement('div'),
       p = document.createElement('p'),
       text = document.createTextNode('Hi there, how are you doing today?');
-  parent.appendChild(p);
   parent.appendChild(text);
+  parent.appendChild(p);
 
-  proclaim.strictEqual(p.nextElementSibling, null);
+  proclaim.strictEqual(p.previousElementSibling, null);
 });
 
 it("should return null if the node only has comment sibling", function () {
   var parent = document.createElement('div'),
       p = document.createElement('p'),
       comment = document.createComment('This is a comment in the document.');
-  parent.appendChild(p);
   parent.appendChild(comment);
+  parent.appendChild(p);
 
-  proclaim.strictEqual(p.nextElementSibling, null);
+  proclaim.strictEqual(p.previousElementSibling, null);
 });
 
 it("should return the first child element", function () {
@@ -38,11 +38,11 @@ it("should return the first child element", function () {
       text = document.createTextNode('Hi there, how are you doing today?'),
       comment = document.createComment('This is a comment in the document.');
   parent.appendChild(h2);
-  parent.appendChild(text);
-  parent.appendChild(comment);
   parent.appendChild(p1);
   parent.appendChild(p2);
+  parent.appendChild(text);
+  parent.appendChild(comment);
   parent.appendChild(p3);
 
-  proclaim.strictEqual(h2.nextElementSibling, p1);
+  proclaim.strictEqual(p3.previousElementSibling, p2);
 });

--- a/polyfills/Element/prototype/previousElementSibling/tests.js
+++ b/polyfills/Element/prototype/previousElementSibling/tests.js
@@ -1,3 +1,6 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
 it("should return null if the node is the only child of its parent node", function () {
   var parent = document.createElement('div'),
       p = document.createElement('p');
@@ -8,7 +11,7 @@ it("should return null if the node is the only child of its parent node", functi
 
 it("should return null if the node only has text sibling", function () {
   var parent = document.createElement('div'),
-      p = document.createElement('p');
+      p = document.createElement('p'),
       text = document.createTextNode('Hi there, how are you doing today?');
   parent.appendChild(p);
   parent.appendChild(text);
@@ -18,7 +21,7 @@ it("should return null if the node only has text sibling", function () {
 
 it("should return null if the node only has comment sibling", function () {
   var parent = document.createElement('div'),
-      p = document.createElement('p');
+      p = document.createElement('p'),
       comment = document.createComment('This is a comment in the document.');
   parent.appendChild(p);
   parent.appendChild(comment);


### PR DESCRIPTION
Raising this to see if I'm on the right track.

## Do we need to polyfill CharacterData?
So it looks like this feature is used in the node type of `NonDocumentTypeChildNode` since it can be `Element` and `CharacterData`. Does this block this improvement, or can we continue and consider a wider `NonDocumentTypeChildNode` polyfill later that would also sort CharacterData?


- [NonDocumentTypeChildNode.nextElementSibling
](https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling#Polyfill_for_Internet_Explorer_9_and_Safari)

Closes https://github.com/Financial-Times/polyfill-library/issues/338