### PR TITLE
Add spec links to [next|previous]ElementSibling

### DIFF
--- a/polyfills/Element/prototype/nextElementSibling/config.toml
+++ b/polyfills/Element/prototype/nextElementSibling/config.toml
@@ -5,6 +5,7 @@ dependencies = [
 ]
 license = "MIT"
 docs = "https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling"
+spec = "https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling"
 
 [browsers]
 # android = "all versions natively support this feature"

--- a/polyfills/Element/prototype/previousElementSibling/config.toml
+++ b/polyfills/Element/prototype/previousElementSibling/config.toml
@@ -5,6 +5,7 @@ dependencies = [
 ]
 license = "MIT"
 docs = "https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/previousElementSibling"
+spec = "https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling"
 
 [browsers]
 # android = "all versions natively support this feature"


### PR DESCRIPTION
I missed these in https://github.com/Financial-Times/polyfill-library/pull/484