### PR TITLE
Fix AudioContext feature detection

### DIFF
--- a/polyfills/AudioContext/detect.js
+++ b/polyfills/AudioContext/detect.js
@@ -1,1 +1,1 @@
-'AudioContext' in self
+'AudioContext' in self || !('webkitAudioContext' in self)


### PR DESCRIPTION
ensure the audio polyfill only runs in browsers which have webkitAudioContext because it depends on this to exist