### PR TITLE
intl update script : fix detect

### DIFF
--- a/polyfills/Intl/PluralRules/update.task.js
+++ b/polyfills/Intl/PluralRules/update.task.js
@@ -61,7 +61,7 @@ function intlLocaleDetectFor(locale) {
 	return "'Intl' in this && " +
 			"Intl.PluralRules && " +
 			"Intl.PluralRules.supportedLocalesOf && " +
-			'(function() { try { return Intl.PluralRules.supportedLocalesOf("' + locale + '").length === 1; } catch (e) { return false; } })';
+			'(function() { try { return Intl.PluralRules.supportedLocalesOf("' + locale + '").length === 1; } catch (e) { return false; } }())';
 }
 
 console.log('Importing Intl.PluralRules~locale.* polyfill from ' + LocalesPath);

--- a/polyfills/Intl/update.task.js
+++ b/polyfills/Intl/update.task.js
@@ -61,13 +61,13 @@ function intlLocaleDetectFor(locale) {
 	return "'Intl' in self && " +
 			"Intl.Collator && " +
 			"Intl.Collator.supportedLocalesOf && " +
-			'(function() { try { return Intl.Collator.supportedLocalesOf("'+locale+'").length === 1; } catch (e) { return false; }})' + " && " +
+			'(function() { try { return Intl.Collator.supportedLocalesOf("'+locale+'").length === 1; } catch (e) { return false; }}())' + " && " +
 			"Intl.DateTimeFormat && " +
 			"Intl.DateTimeFormat.supportedLocalesOf && " +
-			'(function() { try { return Intl.DateTimeFormat.supportedLocalesOf("'+locale+'").length === 1; } catch (e) { return false; } })' + " && " +
+			'(function() { try { return Intl.DateTimeFormat.supportedLocalesOf("'+locale+'").length === 1; } catch (e) { return false; } }())' + " && " +
 			"Intl.NumberFormat && " +
 			"Intl.NumberFormat.supportedLocalesOf && " +
-			'(function() { try { return Intl.NumberFormat.supportedLocalesOf("'+locale+'").length === 1; } catch (e) { return false; } })';
+			'(function() { try { return Intl.NumberFormat.supportedLocalesOf("'+locale+'").length === 1; } catch (e) { return false; } }())';
 }
 
 console.log('Importing Intl.~locale.* polyfill from ' + LocalesPath);


### PR DESCRIPTION
We were seeing this error :

```
Error: No locale data has been added to IntlPluralRules for: , or the default locale: en
```

We think we traced it to the detect script that was updated a few days ago.