### PR TITLE
Make the focusin detect work when document.body does not yet exist

### DIFF
--- a/polyfills/Event/focusin/detect.js
+++ b/polyfills/Event/focusin/detect.js
@@ -1,11 +1,11 @@
 (function() {
   var support = false;
 
-  document.body.addEventListener("focusin", function() {
+  document.documentElement.addEventListener("focusin", function() {
     support = true;
   });
 
-  document.body.dispatchEvent(new Event("focusin"));
+  document.documentElement.dispatchEvent(new Event("focusin"));
 
   return support;
 })()


### PR DESCRIPTION
This situation occurs when the feature-detect is loaded in the <head> element of the document.

Fixes https://github.com/Financial-Times/polyfill-library/issues/511