### PR TITLE
Check and update polyfill targeting once a day automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
             git checkout -b `echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'`;
             git add $i;
             git commit -m "update targets for $i";
-            git push origin;
+            git push origin HEAD;
             hub pull-request --no-edit;
           done
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ jobs:
           for i in `git diff --name-only`; 
           do 
             git checkout master;
+            git config --global user.email "me@jakechampion.name"
+            git config --global user.name "Jake Champion"
             branch_name=`echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'`;
             git checkout -b $branch_name;
             git add $i;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,10 +119,11 @@ jobs:
           for i in `git diff --name-only`; 
           do 
             git checkout master;
-            git checkout -b `echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'`;
+            branch_name=`echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'`;
+            git checkout -b $branch_name;
             git add $i;
             git commit -m "update targets for $i";
-            git push origin HEAD;
+            git push origin $branch_name;
             hub pull-request --no-edit;
           done
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ jobs:
     steps:
       - checkout
       - run: npm ci
+      - run: sudo apt install hub
       - run:
           name: Start test-server
           command: node ./test/polyfills/server.js
@@ -114,7 +115,16 @@ jobs:
       - run: node ./test/polyfills/remotetest.js all
       - run: node ./test/polyfills/compat.js
       - run: node ./test/polyfills/update-polyfill-targeting.js
-      - run: git diff --quiet || for i in `git diff --name-only`; do git checkout master && git checkout -b `echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'` && git add $i && git commit -m "update targets for $i" && git push origin; done
+      - run: >
+          for i in `git diff --name-only`; 
+          do 
+            git checkout master;
+            git checkout -b `echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'`;
+            git add $i;
+            git commit -m "update targets for $i";
+            git push origin;
+            hub pull-request --no-edit;
+          done
 workflows:
   update_polyfill_targets:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
       - run: node ./test/polyfills/remotetest.js control
       - run: node ./test/polyfills/remotetest.js all
       - run: node ./test/polyfills/compat.js
-      - run: node ./test/polyfills/update-polyfill-targeting.js 
+      - run: node ./test/polyfills/update-polyfill-targeting.js
+      - run: git diff --quiet || for i in `git diff --name-only`; do git checkout master && git checkout -b `echo $i | sed 's/polyfills\///' | sed 's/\/config\.toml//'` && git add $i && git commit -m "update targets for $i" && git push origin; done
 workflows:
   update_polyfill_targets:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,24 +100,31 @@ jobs:
           command: node ./test/polyfills/server.js
           background: true
       - run: node ./test/polyfills/remotetest.js targeted director browser=safari
-  # update_polyfill_targets:
-  #   docker:
-  #     - image: circleci/node:10
-  #   steps:
-  #     - checkout
-  #     - run: npm ci
-  #     - run:
-  #         name: Start test-server
-  #         command: node ./test/polyfills/server.js
-  #         background: true
-  #     - run: node ./test/polyfills/remotetest.js compat
-  #     - run: node ./test/polyfills/remotetest.js all
-  #     - run: node ./test/polyfills/compat.js
-  #     - run: node ./test/polyfills/update-polyfill-targeting.js
+  update_polyfill_targets:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run: npm ci
+      - run:
+          name: Start test-server
+          command: node ./test/polyfills/server.js
+          background: true
+      - run: node ./test/polyfills/remotetest.js control
+      - run: node ./test/polyfills/remotetest.js all
+      - run: node ./test/polyfills/compat.js
+      - run: node ./test/polyfills/update-polyfill-targeting.js 
 workflows:
-  # update_polyfill_targets:
-  #   jobs:
-  #     - update_polyfill_targets
+  update_polyfill_targets:
+    jobs:
+      - update_polyfill_targets
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
   test:
     jobs:
       - lint_js:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ polyfills/String/prototype/normalize/polyfill.js
 polyfills/AbortController/polyfill.js
 polyfills/smoothscroll/polyfill.js
 local.log
+test/polyfills/compat.json
+test/polyfills/results-all.json
+test/polyfills/results-control.json

--- a/test/polyfills/compat.js
+++ b/test/polyfills/compat.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const fs = require("fs-extra");
+const path = require("path");
+const _ = require('lodash');
+
+const intersection = (a, b) =>
+  new Set(Array.from(b).filter(value => a.has(value)));
+const difference = (a, b) =>
+  new Set(Array.from(b).filter(value => !a.has(value)));
+
+console.log("Reading test result data");
+const control = fs.readJSONSync(path.join(__dirname, "results-control.json"));
+const all = fs.readJSONSync(path.join(__dirname, "results-all.json"));
+
+const compat = _.merge({}, control, all);
+const builtCompatTable = {};
+
+Object.keys(compat).forEach(browserName => {
+  const versions = compat[browserName];
+  Object.keys(versions).forEach(version => {
+    const testResults = versions[version];
+    if (!testResults.all || !testResults.control) {
+      throw new Error(
+        "Missing test results for " + browserName + "/" + version
+      );
+    }
+
+    const allTests = new Set(Array.from(testResults.control.testedSuites));
+    const failedNative = new Set(Array.from(testResults.control.failingSuites));
+    const failedPolyfilled = new Set(Array.from(testResults.all.failingSuites));
+
+    const missing = intersection(failedNative, failedPolyfilled);
+    const polyfilled = difference(failedPolyfilled, failedNative);
+    const native = difference(failedNative, allTests);
+
+    function buildData(support) {
+      return function(feature) {
+        if (!builtCompatTable[feature]) {
+          builtCompatTable[feature] = {};
+        }
+
+        if (!builtCompatTable[feature][browserName]) {
+          builtCompatTable[feature][browserName] = {};
+        }
+
+        builtCompatTable[feature][browserName][version] = support;
+      };
+    }
+
+    native.forEach(buildData("native"));
+    polyfilled.forEach(buildData("polyfilled"));
+    missing.forEach(buildData("missing"));
+  });
+});
+
+const compatFile = path.join(__dirname, "compat.json");
+fs.writeFileSync(compatFile, JSON.stringify(builtCompatTable, null, 2));
+console.log("Updated compat.json");

--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -210,7 +210,7 @@ const printProgress = (function() {
             .run()
             .then(job => {
               if (job.state === "complete") {
-                const [family, version] = job.name.split("/");
+                const [family, version] = normalizeUserAgent(job.useragent).split("/");
                 _.set(
                   testResults,
                   [family, version, job.mode],

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -82,7 +82,7 @@ module.exports = class TestJob {
 
   async run() {
     try {
-      // this.setState("connecting to browser");
+      this.setState("connecting to browser");
       this.browser = await remote({
         maxInstances: 1,
         logLevel: "warn",
@@ -119,6 +119,11 @@ module.exports = class TestJob {
 
     try {
       await this.setState("started");
+      this.useragent = await this.browser.execute(function () {
+        // browser context - you may not access client or console
+        // eslint-disable-next-line no-undef
+        return navigator.userAgent;
+      });
       await this.browser.navigateTo(this.url);
       await this.setState("loaded URL");
       await wait(this.pollTick);

--- a/test/polyfills/update-polyfill-targeting.js
+++ b/test/polyfills/update-polyfill-targeting.js
@@ -10,7 +10,7 @@ async function main() {
 	const file = path.join(__dirname, "./compat.json");
 	// Ensure file exists before proceeding.
 	if (!fs.existsSync(file)) {
-		throw new Error("Compat results file does not exists, to create the file you need to run the command: `npm run generate-compat-data`.");
+		throw new Error("Compat results file does not exists, to create the file you need to run the command: `node ./test/polyfills/compat.js`.");
 	}
 	const compat = await fs.readJSON(file);
 	const changes = [];

--- a/test/polyfills/update-polyfill-targeting.js
+++ b/test/polyfills/update-polyfill-targeting.js
@@ -7,74 +7,121 @@ const polyfillLibrary = require("../../lib/index");
 const TOML = require("@iarna/toml");
 
 async function main() {
-	const file = path.join(__dirname, "./compat.json");
-	// Ensure file exists before proceeding.
-	if (!fs.existsSync(file)) {
-		throw new Error("Compat results file does not exists, to create the file you need to run the command: `node ./test/polyfills/compat.js`.");
-	}
-	const compat = await fs.readJSON(file);
-	const changes = [];
-	for (let feature of Object.keys(compat)) {
-		feature = feature.split(" ")[0];
-		const featureMetadata = await polyfillLibrary.describePolyfill(feature);
-		if (!featureMetadata) {
-			throw new Error(`${feature} does not exists within the polyfill-library.`);
-		}
+  const file = path.join(__dirname, "./compat.json");
+  // Ensure file exists before proceeding.
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      "Compat results file does not exists, to create the file you need to run the command: `node ./test/polyfills/compat.js`."
+    );
+  }
+  const compat = await fs.readJSON(file);
+  const changes = [];
+  for (let feature of Object.keys(compat)) {
+    feature = feature.split(" ")[0];
+    const featureMetadata = await polyfillLibrary.describePolyfill(feature);
+    if (!featureMetadata) {
+      throw new Error(
+        `${feature} does not exists within the polyfill-library.`
+      );
+    }
 
-		for (const browser of Object.keys(compat[feature])) {
-			for (const [version, support] of Object.entries(compat[feature][browser])) {
-				if (support === "native") {
-					if (featureMetadata.browsers && featureMetadata.browsers[browser] && semver.satisfies(semver.coerce(version), featureMetadata.browsers[browser])) {
-						changes.push([feature + "|" + browser, JSON.stringify({ [browser]: `<${version}` })]);
-					}
-				}
-				if (support === "polyfilled") {
-					if (!featureMetadata.browsers || !featureMetadata.browsers[browser] || !semver.satisfies(semver.coerce(version), featureMetadata.browsers[browser])) {
-						changes.push([feature + "|" + browser, JSON.stringify({ [browser]: `<${Number.parseFloat(version) + 1}` })]);
-					}
-				}
+    for (const browser of Object.keys(compat[feature])) {
+      for (const [version, support] of Object.entries(
+        compat[feature][browser]
+      )) {
+        if (support === "native") {
+          if (
+            featureMetadata.browsers &&
+            featureMetadata.browsers[browser] &&
+            semver.satisfies(
+              semver.coerce(version),
+              featureMetadata.browsers[browser]
+            )
+          ) {
+            changes.push([
+              feature + "|" + browser,
+              JSON.stringify({ [browser]: `<${version}` })
+            ]);
+          }
+        }
+        if (support === "polyfilled") {
+          if (
+            !featureMetadata.browsers ||
+            !featureMetadata.browsers[browser] ||
+            !semver.satisfies(
+              semver.coerce(version),
+              featureMetadata.browsers[browser]
+            )
+          ) {
+            changes.push([
+              feature + "|" + browser,
+              JSON.stringify({
+                [browser]: `<${Number.parseFloat(version) + 1}`
+              })
+            ]);
+          }
+        }
 
-				if (support === "missing") {
-					if (!featureMetadata.browsers || !featureMetadata.browsers[browser] || !semver.satisfies(semver.coerce(version), featureMetadata.browsers[browser])) {
-						changes.push([feature + "|" + browser,JSON.stringify({ [browser]: `<${Number.parseFloat(version) + 1}` })]);
-					}
-				}
-			}
-		}
-	}
+        if (support === "missing") {
+          if (
+            !featureMetadata.browsers ||
+            !featureMetadata.browsers[browser] ||
+            !semver.satisfies(
+              semver.coerce(version),
+              featureMetadata.browsers[browser]
+            )
+          ) {
+            changes.push([
+              feature + "|" + browser,
+              JSON.stringify({
+                [browser]: `<${Number.parseFloat(version) + 1}`
+              })
+            ]);
+          }
+        }
+      }
+    }
+  }
 
-	async function updateFeature(feature, update) {
-		const configPath = path.join(__dirname, "../../polyfills", feature.join("/").replace('.', '/'), "config.toml");
-		const config = TOML.parse(await fs.readFile(configPath, 'utf-8'));
-		config.browsers = config.browsers || {};
-		config.browsers = Object.assign(config.browsers, JSON.parse(update));
-        await fs.writeFile(configPath, TOML.stringify(config), 'utf-8');
-	}
-	if (changes.length > 0) {
-		for (const [featureWithBrowser, value] of changes) {
-			const [feature] = featureWithBrowser.split("|");
-			if (typeof value === "object") {
-				for (const [featureWithBrowser2, value2] of Object.entries(value)) {
-					const [feature2] = featureWithBrowser2.split("|");
-					if (typeof value2 === "object") {
-						for (const [featureWithBrowser3, value3] of Object.entries(value2)) {
-							const [feature3] = featureWithBrowser3.split("|");
-							await updateFeature([feature, feature2, feature3], value3);
-						}
-					} else {
-						await updateFeature([feature, feature2], value2);
-					}
-				}
-			} else {
-				await updateFeature([feature], value);
-			}
-		}
-	} else {
-		console.log("All browsers have correctly configured polyfills. Nice!");
-	}
+  async function updateFeature(feature, update) {
+    const configPath = path.join(
+      __dirname,
+      "../../polyfills",
+      feature.join("/").replace(".", "/"),
+      "config.toml"
+    );
+    const config = TOML.parse(await fs.readFile(configPath, "utf-8"));
+    config.browsers = config.browsers || {};
+    config.browsers = Object.assign(config.browsers, JSON.parse(update));
+    await fs.writeFile(configPath, TOML.stringify(config), "utf-8");
+  }
+  if (changes.length > 0) {
+    for (const [featureWithBrowser, value] of changes) {
+      const [feature] = featureWithBrowser.split("|");
+      if (typeof value === "object") {
+        for (const [featureWithBrowser2, value2] of Object.entries(value)) {
+          const [feature2] = featureWithBrowser2.split("|");
+          if (typeof value2 === "object") {
+            for (const [featureWithBrowser3, value3] of Object.entries(
+              value2
+            )) {
+              const [feature3] = featureWithBrowser3.split("|");
+              await updateFeature([feature, feature2, feature3], value3);
+            }
+          } else {
+            await updateFeature([feature, feature2], value2);
+          }
+        }
+      } else {
+        await updateFeature([feature], value);
+      }
+    }
+  } else {
+    console.log("All browsers have correctly configured polyfills. Nice!");
+  }
 }
 
 main().catch(e => {
-	console.error(e);
-	process.exitCode = 1;
+  console.error(e);
+  process.exitCode = 1;
 });

--- a/test/polyfills/update-polyfill-targeting.js
+++ b/test/polyfills/update-polyfill-targeting.js
@@ -18,11 +18,6 @@ async function main() {
   const changes = [];
   for (const feature of Object.keys(compat)) {
     const featureMetadata = await polyfillLibrary.describePolyfill(feature);
-    if (!featureMetadata) {
-      throw new Error(
-        `${feature} does not exists within the polyfill-library.`
-      );
-    }
 
     for (const browser of Object.keys(compat[feature])) {
       for (const [version, support] of Object.entries(

--- a/test/polyfills/update-polyfill-targeting.js
+++ b/test/polyfills/update-polyfill-targeting.js
@@ -16,8 +16,7 @@ async function main() {
   }
   const compat = await fs.readJSON(file);
   const changes = [];
-  for (let feature of Object.keys(compat)) {
-    feature = feature.split(" ")[0];
+  for (const feature of Object.keys(compat)) {
     const featureMetadata = await polyfillLibrary.describePolyfill(feature);
     if (!featureMetadata) {
       throw new Error(


### PR DESCRIPTION
This creates a CircleCI job to run once a day which:
- Runs the tests without any polyfills
- Runs the tests with polyfills
- Updates each polyfill config file which need to be updated (I.E. Chrome latest no longer needs polyfills for `Map.from` or something like that)
- Creates a pull-request for each separate polyfill update