### PR TITLE
Ship Math.hypot to chrome 77

### DIFF
--- a/polyfills/Math/hypot/config.toml
+++ b/polyfills/Math/hypot/config.toml
@@ -6,7 +6,7 @@ spec = "https://tc39.github.io/ecma262/#sec-math.hypot"
 [browsers]
 android = "<5"
 bb = "*"
-chrome = "<38"
+chrome = "<38 || 77"
 edge = "<12"
 edge_mob = "<12"
 firefox = "<27"
@@ -19,4 +19,3 @@ op_mob = "*"
 op_mini = "*"
 safari = "<8"
 firefox_mob = "<27"
-


### PR DESCRIPTION
 as it's implementation does not return `NaN` for `Math.hypot(undefined,0)` and instead returns `0`