### PR TITLE
serve element.prototype.matches to edge versions below 18

### DIFF
--- a/polyfills/Element/prototype/matches/config.toml
+++ b/polyfills/Element/prototype/matches/config.toml
@@ -12,8 +12,8 @@ docs = "https://developer.mozilla.org/en-US/docs/Web/API/Element/matches"
 spec = "http://dom.spec.whatwg.org/#dom-element-matches"
 
 [browsers]
-edge = "<12"
-edge_mob = "<12"
+edge = "<18"
+edge_mob = "<18"
 ie = "6 - *"
 ie_mob = "10 - 11"
 chrome = "* - 33"


### PR DESCRIPTION
fixes https://github.com/Financial-Times/polyfill-library/issues/541

Browser support gathered from MDN -- https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Browser_compatibility