### PR TITLE
catch exception when polyfill file doesn't exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,6 +182,13 @@ async function getPolyfills(options_) {
     }
 
     const meta = await sources.getPolyfillMeta(featureName);
+    if (!meta) {
+      // this is a bit strange but the best thing I could come up with.
+      // by adding the feature, it will show up as an "unrecognized" polyfill
+      // which I think is better than just pretending it doesn't exsist.
+      addFeature(featureName);
+      continue;
+    }
     // If not already targeted, check to see if the polyfill's configuration states it should target
     // this browser version.
     if (!targeted) {

--- a/lib/sources.js
+++ b/lib/sources.js
@@ -26,7 +26,7 @@ async function getPolyfillMeta(featureName) {
       );
       meta = JSON.parse(meta);
       polyfillMetaCache.set(featureName, meta);
-    } catch (e) {
+    } catch (error) {
       // if file doesn't exist
       meta = undefined;
     }

--- a/lib/sources.js
+++ b/lib/sources.js
@@ -26,7 +26,7 @@ async function getPolyfillMeta(featureName) {
       );
       meta = JSON.parse(meta);
       polyfillMetaCache.set(featureName, meta);
-    } catch {
+    } catch (e) {
       // if file doesn't exist
       meta = undefined;
     }

--- a/lib/sources.js
+++ b/lib/sources.js
@@ -19,12 +19,17 @@ const polyfillDirectory = path.join(__dirname, "../polyfills/__dist");
 async function getPolyfillMeta(featureName) {
   let meta = polyfillMetaCache.get(featureName);
   if (meta === undefined) {
-    meta = await readFile(
-      path.join(polyfillDirectory, featureName, "meta.json"),
-      "UTF-8"
-    );
-    meta = JSON.parse(meta);
-    polyfillMetaCache.set(featureName, meta);
+    try {
+      meta = await readFile(
+	path.join(polyfillDirectory, featureName, "meta.json"),
+	"UTF-8"
+      );
+      meta = JSON.parse(meta);
+      polyfillMetaCache.set(featureName, meta);
+    } catch {
+      // if file doesn't exist
+      meta = undefined;
+    }
   }
   return meta;
 }


### PR DESCRIPTION
This fixes an error I was getting when a polyfill was requested that doesn't exist.