### PR TITLE
Polyfill Intl.PluralRules on Edge <18

### DIFF
--- a/polyfills/Intl/PluralRules/config.toml
+++ b/polyfills/Intl/PluralRules/config.toml
@@ -9,6 +9,7 @@ notes = [
 
 [browsers]
 android = "<63"
+edge = "<18"
 ie = "9 - *"
 ie_mob = "9 - *"
 firefox = "<58"


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules#Browser_compatibility) and some exceptions we're seeing, Edge <18 doesn't ship with support for Intl.PluralRules

Addresses #633