### PR TITLE
Use seamless-scroll-polyfill for smoothscroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5116,6 +5116,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "seamless-scroll-polyfill": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/seamless-scroll-polyfill/-/seamless-scroll-polyfill-1.0.10.tgz",
+      "integrity": "sha512-T6kBngvA2600YSmIEAQUpjvM77dDxNOXuTqAaCE8Y2bjb5pITHVdxvds+e7dIL4gdA3QczQrmgpCWTRMGpodqQ=="
+    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -5275,11 +5280,6 @@
           "dev": true
         }
       }
-    },
-    "smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
     },
     "socket.io": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "picturefill": "^3.0.1",
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^3.0.0",
-    "smoothscroll-polyfill": "^0.4.4",
+    "seamless-scroll-polyfill": "^1.0.10",
     "spdx-licenses": "^1.0.0",
     "stream-cache": "^0.0.2",
     "stream-from-promise": "^1.0.0",

--- a/polyfills/smoothscroll/config.toml
+++ b/polyfills/smoothscroll/config.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 license = "MIT"
 spec = "https://drafts.csswg.org/cssom-view/#smooth-scrolling"
-repo = "https://github.com/iamdustan/smoothscroll"
+repo = "https://github.com/magic-akari/seamless-scroll-polyfill"
 docs = "https://developer.mozilla.org/en/docs/Web/CSS/scroll-behavior"
 
 [browsers]
@@ -32,5 +32,5 @@ ios_saf = "*"
 android = "*"
 
 [install]
-module = "smoothscroll-polyfill"
+module = "seamless-scroll-polyfill"
 postinstall = "update.task.js"

--- a/polyfills/smoothscroll/detect.js
+++ b/polyfills/smoothscroll/detect.js
@@ -11,7 +11,10 @@
             get: function () {
                 supportsSmoothScroll = true;
                 return 'smooth';
-            }
+            },
+
+            // Ensure this property lasts through cloning / destructuring:
+            enumerable: true
         });
 
         document.body.scrollTo(scrollOptions);

--- a/polyfills/smoothscroll/patch.jsdiff
+++ b/polyfills/smoothscroll/patch.jsdiff
@@ -1,19 +1,34 @@
 ===================================================================
---- a/polyfills/smoothscroll/polyfill.js
-+++ b/polyfills/smoothscroll/polyfill.js
-@@ -421,13 +421,8 @@
-       }
+--- a/polyfills/smoothscroll/polyfill-original.js
++++ b/polyfills/smoothscroll/polyfill-original.js
+@@ -1,8 +1,5 @@
+-(function (global, factory) {
+-    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+-    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+-    (global = global || self, factory(global.seamless = {}));
+-}(this, (function (exports) { 'use strict';
++(function () {
++    'use strict';
+
+     /*! *****************************************************************************
+     Copyright (c) Microsoft Corporation. All rights reserved.
+@@ -701,17 +698,7 @@
+         polyfill$2(options);
      };
-   }
- 
--  if (typeof exports === 'object' && typeof module !== 'undefined') {
--    // commonjs
--    module.exports = { polyfill: polyfill };
--  } else {
--    // global
--    polyfill();
--  }
-+  // global
-+  polyfill();
- 
- }());
+
+-    exports.elementScroll = elementScroll;
+-    exports.elementScrollBy = elementScrollBy;
+-    exports.elementScrollIntoView = elementScrollIntoView;
+-    exports.elementScrollTo = elementScroll;
+-    exports.polyfill = polyfill$7;
+-    exports.seamless = polyfill$7;
+-    exports.windowScroll = windowScroll;
+-    exports.windowScrollBy = windowScrollBy;
+-    exports.windowScrollTo = windowScroll;
++    polyfill$7();
+
+-    Object.defineProperty(exports, '__esModule', { value: true });
+-
+-})));
++})();
+//# sourceMappingURL=seamless.js.map

--- a/tasks/node/updatesources.js
+++ b/tasks/node/updatesources.js
@@ -61,7 +61,7 @@ glob('polyfills/**/config.toml', globOptions)
 				}
 			})
             .filter(config => 'install' in config)
-            .forEach(installPolyfill);
+            .forEach(toml => installPolyfill(toml));
         
     })
     .then(() => console.log('Polyfills updated successfully'))

--- a/test/polyfills/compat.js
+++ b/test/polyfills/compat.js
@@ -48,12 +48,12 @@ Object.keys(compat).forEach(browserName => {
       };
     }
 
-    native.forEach(buildData("native"));
-    polyfilled.forEach(buildData("polyfilled"));
-    missing.forEach(buildData("missing"));
+    native.forEach(feature => buildData("native")(feature));
+    polyfilled.forEach(feature => buildData("polyfilled")(feature));
+    missing.forEach(feature => buildData("missing")(feature));
   });
 });
 
 const compatFile = path.join(__dirname, "compat.json");
-fs.writeFileSync(compatFile, JSON.stringify(builtCompatTable, null, 2));
+fs.writeFileSync(compatFile, JSON.stringify(builtCompatTable, undefined, 2));
 console.log("Updated compat.json");

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -25,7 +25,7 @@ module.exports = class TestJob {
     this.name = name;
     this.mode = mode;
     this.url = url;
-    this.results = null;
+    this.results = undefined;
     this.lastUpdateTime = 0;
     this.duration = 0;
     // BrowserStack options https://www.browserstack.com/automate/capabilities


### PR DESCRIPTION
Previously, polyfill-library used smoothscroll-polyfill. That library is no longer well-maintained and is missing some parts of the smoothscroll spec.

This commit swaps in seamless-scroll-polyfill, which is a better-maintained fork of smoothscroll-polyfill.

Resolves #657