### PR TITLE
Formdata

### DIFF
--- a/polyfills/FormData/config.toml
+++ b/polyfills/FormData/config.toml
@@ -1,0 +1,25 @@
+aliases = [
+  "default-3.3",
+  "default-3.4",
+  "default-3.5",
+  "default-3.6",
+  "default",
+]
+dependencies = [ "Blob", "URLSearchParams", "XMLHttpRequest" ]
+spec = "https://xhr.spec.whatwg.org/#interface-formdata"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/FormData"
+license = "MIT"
+repo = "https://github.com/jimmywarting/FormData"
+
+[browsers]
+android = "<=4.4"
+chrome = "<50"
+chrome_mob = "<50"
+ie_mob = "10 - *"
+edge = "<18"
+edge_mob = "*"
+firefox = "<45"
+firefox_mob = "<45"
+safari = "<12"
+ie = "<11"
+opera = "<15"

--- a/polyfills/FormData/detect.js
+++ b/polyfills/FormData/detect.js
@@ -1,0 +1,1 @@
+typeof self.Blob !== 'undefined' && 'FormData' in self && 'keys' in self.FormData.prototype


### PR DESCRIPTION
This PR enables the **FormData** constructor and instance APIs (e.g. *set()*, *keys()*, *entries()* ) using a polyfill located [here](https://github.com/jimmywarting/FormData)