### PR TITLE
Fix Map regression introduced in #219

### DIFF
--- a/polyfills/Map/polyfill.js
+++ b/polyfills/Map/polyfill.js
@@ -36,7 +36,7 @@
 				// Return `false`
 				return false;
 			}
-			if (!recordKey[_metaKey]) {
+			if (!Object.prototype.hasOwnProperty.call(recordKey, _metaKey)) {
 				var uniqueHashKey = typeof(recordKey)+'-'+(++_uniqueHashId);
 				Object.defineProperty(recordKey, _metaKey, {
 					configurable: false,

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -483,27 +483,16 @@ describe('Map', function () {
 		proclaim.equal(o.get(""), 'test value');
 		
 		if (Object.create && Object.setPrototypeOf) {
-			function inherits(subClass, superClass) {
-				subClass.prototype = Object.create(superClass.prototype);
-				subClass.prototype.constructor = subClass;
-				Object.setPrototypeOf(subClass, superClass);
+			function BaseClass() {
+				// Empty class
 			}
-
-			var BaseClass = function() {
-				function BaseClass() {
-				}
-
-				return BaseClass;
-			}();
-
-			var SubClass = function() {
-				inherits(SubClass, BaseClass);
-
-				function SubClass() {
-				}
-
-				return SubClass;
-			}();
+			function SubClass() {
+				// Empty class
+			}
+			
+			SubClass.prototype = Object.create(BaseClass.prototype);
+			SubClass.prototype.constructor = SubClass;
+			Object.setPrototypeOf(SubClass, BaseClass);
 
 			o.set(BaseClass, "base class");
 			o.set(SubClass, "sub class");

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -483,10 +483,10 @@ describe('Map', function () {
 		proclaim.equal(o.get(""), 'test value');
 		
 		if (Object.create && Object.setPrototypeOf) {
-			function BaseClass() {
+			function BaseClass() { // eslint-disable-line no-inner-declarations
 				// Empty class
 			}
-			function SubClass() {
+			function SubClass() { // eslint-disable-line no-inner-declarations
 				// Empty class
 			}
 			

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -481,6 +481,33 @@ describe('Map', function () {
 
 		o.set("", "test value");
 		proclaim.equal(o.get(""), 'test value');
+		
+		function inherits(subClass, superClass) {
+			subClass.prototype = Object.create(superClass.prototype);
+			subClass.prototype.constructor = subClass;
+			Object.setPrototypeOf(subClass, superClass);
+		}
+
+		var BaseClass = function() {
+			function BaseClass() {
+			}
+
+			return BaseClass;
+		}();
+
+		var SubClass = function() {
+			inherits(SubClass, BaseClass);
+
+			function SubClass() {
+			}
+
+			return SubClass;
+		}();
+
+		o.set(BaseClass, "base class");
+		o.set(SubClass, "sub class");
+		proclaim.equal(o.get(BaseClass), "base class");
+		proclaim.equal(o.get(SubClass), "sub class");
 	});
 
 	it("implements .delete()", function () {

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -482,32 +482,34 @@ describe('Map', function () {
 		o.set("", "test value");
 		proclaim.equal(o.get(""), 'test value');
 		
-		function inherits(subClass, superClass) {
-			subClass.prototype = Object.create(superClass.prototype);
-			subClass.prototype.constructor = subClass;
-			Object.setPrototypeOf(subClass, superClass);
+		if (Object.create && Object.setPrototypeOf) {
+			function inherits(subClass, superClass) {
+				subClass.prototype = Object.create(superClass.prototype);
+				subClass.prototype.constructor = subClass;
+				Object.setPrototypeOf(subClass, superClass);
+			}
+
+			var BaseClass = function() {
+				function BaseClass() {
+				}
+
+				return BaseClass;
+			}();
+
+			var SubClass = function() {
+				inherits(SubClass, BaseClass);
+
+				function SubClass() {
+				}
+
+				return SubClass;
+			}();
+
+			o.set(BaseClass, "base class");
+			o.set(SubClass, "sub class");
+			proclaim.equal(o.get(BaseClass), "base class");
+			proclaim.equal(o.get(SubClass), "sub class");
 		}
-
-		var BaseClass = function() {
-			function BaseClass() {
-			}
-
-			return BaseClass;
-		}();
-
-		var SubClass = function() {
-			inherits(SubClass, BaseClass);
-
-			function SubClass() {
-			}
-
-			return SubClass;
-		}();
-
-		o.set(BaseClass, "base class");
-		o.set(SubClass, "sub class");
-		proclaim.equal(o.get(BaseClass), "base class");
-		proclaim.equal(o.get(SubClass), "sub class");
 	});
 
 	it("implements .delete()", function () {


### PR DESCRIPTION
This fix resolves an issue where classes are used as Map keys.

The present behavior is that a base class and sub class resolves the same entry. The desired behavior is for them to resolve to different entries.

Test that reproduces the bug and the fix are included.

This regression has made it impossible to use Polyfill.io for aurelia apps in IE.