### PR TITLE
Fix "finally" support for Chrome 63

### DIFF
--- a/polyfills/Promise/prototype/finally/config.toml
+++ b/polyfills/Promise/prototype/finally/config.toml
@@ -13,9 +13,9 @@ license = "MIT"
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally"
 
 [browsers]
-android = ">4.4 <63"
+android = ">4.4 <64"
 bb = ">10"
-chrome = ">31 <63"
+chrome = ">31 <64"
 firefox = ">28 <58"
 ios_saf = ">7.1 <11.3"
 edge = ">12 <18"


### PR DESCRIPTION
I was able to track down, through a bunch of investigation, that `Promise.prototype.finally` wasn't actually added into Chrome until at least version 63.0.3219

I'm hoping that the main lib supports specifying minor versions this way, otherwise we might have to just change this to `< 64`?