### PR TITLE
Improve the message when no polyfills are required to be served to the requesting browser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -376,7 +376,7 @@ function getPolyfillString(options_) {
         if (!options.minify) {
           output.add(
             streamFromString(
-              "\n/* No polyfills found for current settings */\n\n"
+              "\n/* No polyfills needed for current settings and browser */\n\n"
             )
           );
         }


### PR DESCRIPTION
The suggestion came from @jossnaz in the polyfill-service repo https://github.com/Financial-Times/polyfill-service/issues/2280#issuecomment-665852215