### PR TITLE
exit test-polyfills workflow early if running from a forked repo.

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check-for-other-pull-requests-running-this-workflow:
     runs-on: ubuntu-latest
+    if: ${{ github.pull_request.head.repo.fork == false}}
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.4.1


### PR DESCRIPTION
This is because the workflow will fail due to not having access to the secrets required for browserstack to run.

We want to exit early because then we will not have this workflow run be marked as a failure. Having the workflow get marked as a failure will make a GitHub notifcation/email be sent to whoever follows the builds for polyfill-library (such as myself).