### PR TITLE
Move to Github's native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,9 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    rebase-strategy: "disabled"
     ignore:
-      - dependency-name: "snyk"
+      - dependency-name: "mocha"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,3 +17,4 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
-    rebase-strategy: "disabled"
     ignore:
-      - dependency-name: "mocha"
+      - dependency-name: "snyk"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,4 +16,3 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
-    rebase-strategy: "disabled"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -36,5 +36,3 @@ jobs:
           MERGE_LABELS: "dependencies"
           MERGE_METHOD: "rebase"
           MERGE_FORKS: "false"
-          UPDATE_LABELS: ""
-          UPDATE_METHOD: "rebase"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,6 @@
 name: automerge
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - unlabeled
@@ -23,16 +23,18 @@ jobs:
     steps:
       - name: 'Wait for status checks'
         id: waitforstatuschecks
-        uses: "WyriHaximus/github-action-wait-for-status@v1.1.2"
+        uses: "WyriHaximus/github-action-wait-for-status@v1.1"
         with:
           ignoreActions: automerge
           checkInterval: 13
         env:
-          GITHUB_TOKEN: "${{ secrets.ORIGAMI_GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: automerge
-        uses: "JakeChampion/automerge-action@patch-1"
+        uses: "pascalgn/automerge-action@v0.9.0"
         env:
           GITHUB_TOKEN: "${{ secrets.ORIGAMI_GITHUB_TOKEN }}"
           MERGE_LABELS: "dependencies"
           MERGE_METHOD: "rebase"
           MERGE_FORKS: "false"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "rebase"


### PR DESCRIPTION
This change has already been applied to polyfill-library and has shown to be working well 😄

Part of -- https://github.com/Financial-Times/origami/pull/63