### PR TITLE
memoize testablePolyfills in test/polyfills/server.js

### DIFF
--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -128,7 +128,12 @@ app.get(
 
 app.listen(port, () => console.log(`Test server listening on port ${port}!`));
 
+const testablePolyfillsCache = {};
 async function testablePolyfills(isIE8, ua) {
+  if (testablePolyfillsCache[`isIE8:${isIE8};ua:${ua}`]) {
+    return testablePolyfillsCache[`isIE8:${isIE8};ua:${ua}`];
+  }
+
   const polyfills = await polyfillio.listAllPolyfills();
   const polyfilldata = [];
 
@@ -171,6 +176,7 @@ async function testablePolyfills(isIE8, ua) {
     return a.feature > b.feature ? -1 : 1;
   });
 
+  testablePolyfillsCache[`isIE8:${isIE8};ua:${ua}`] = polyfilldata;
   return polyfilldata;
 }
 


### PR DESCRIPTION
Noticed that a lot of work is done in `test/polyfills/server.js:132` `testablePolyfills` and that this work is the same for each tested polyfill.

By memoizing the results tests run a lot faster.

Before :

<img width="1111" alt="Screenshot 2020-10-07 at 10 44 45" src="https://user-images.githubusercontent.com/11521496/95308475-402afc00-088a-11eb-8e75-6c7dfec3eb55.png">

After :

<img width="1096" alt="Screenshot 2020-10-07 at 10 44 52" src="https://user-images.githubusercontent.com/11521496/95308482-41f4bf80-088a-11eb-9f60-aca48b91ece6.png">

--------------

When combined with a [parallel build script](https://github.com/Financial-Times/polyfill-library/issues/887)

<img width="1099" alt="Screenshot 2020-10-07 at 10 55 39" src="https://user-images.githubusercontent.com/11521496/95310210-6baee600-088c-11eb-827d-0e5b39f4e442.png">

Chrome before :

<img width="1098" alt="Screenshot 2020-10-07 at 11 24 11" src="https://user-images.githubusercontent.com/11521496/95312854-bf6efe80-088f-11eb-85f0-db5cd8aefd05.png">

Chrome after :

<img width="1098" alt="Screenshot 2020-10-07 at 11 23 59" src="https://user-images.githubusercontent.com/11521496/95312885-c85fd000-088f-11eb-81e2-0602f9b00cdb.png">
