### PR TITLE
more tests and lints for feature detect.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,6 +2145,12 @@
         "lodash.zip": "^4.2.0"
       }
     },
+    "eslint-plugin-uncalled-iife": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-uncalled-iife/-/eslint-plugin-uncalled-iife-1.0.0.tgz",
+      "integrity": "sha512-/vu9WZnnrr3YkjrFu4PhjfISLq80NlJw3XSETo8jvxgIn4KiOlf1CAw4fKWhm9NLY7Qsg/h5TDnu2wclnXksfA==",
+      "dev": true
+    },
     "eslint-plugin-unicorn": {
       "version": "19.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-19.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "cli-color": "^2.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
+    "eslint-plugin-uncalled-iife": "^1.0.0",
     "eslint-plugin-unicorn": "^19.0.1",
     "execa": "^4.0.0",
     "express": "^4.17.1",

--- a/polyfills/.eslintrc
+++ b/polyfills/.eslintrc
@@ -18,6 +18,9 @@
     "no-dupe-else-if": "error",
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   },
+  "plugins": [
+    "uncalled-iife"
+  ],
   "overrides": [
     {
       "files": ["update.task.js"],
@@ -35,6 +38,12 @@
       "env": {
         "mocha": true,
         "browser": true
+      }
+    },
+    {
+      "files": ["detect.js"],
+      "rules": {
+         "uncalled-iife/uncalled-iife": "error"
       }
     }
   ],

--- a/polyfills/Array/prototype/sort/detect.js
+++ b/polyfills/Array/prototype/sort/detect.js
@@ -2,4 +2,4 @@
     // Check it does a stable sort
     var obj = {length:3, 0:2, 1:1,2:3};
     return Array.prototype.sort.call(obj, function(a,b) {return a-b}) === obj;
-})
+}())

--- a/polyfills/DOMTokenList/prototype/@@iterator/detect.js
+++ b/polyfills/DOMTokenList/prototype/@@iterator/detect.js
@@ -1,7 +1,7 @@
 'Symbol' in self && 'iterator' in self.Symbol && (function(){
     try {
         var div = document.createElement('div');
-        return div.classList && div.classList[self.Symbol.iterator];
+        return !!(div.classList && div.classList[self.Symbol.iterator]);
     } catch (err) {
         return false;
     }

--- a/polyfills/DOMTokenList/prototype/replace/detect.js
+++ b/polyfills/DOMTokenList/prototype/replace/detect.js
@@ -1,1 +1,1 @@
-(document.createElement('div').classList || {}).replace
+"replace" in (document.createElement('div').classList || {})

--- a/polyfills/DocumentFragment/config.toml
+++ b/polyfills/DocumentFragment/config.toml
@@ -1,5 +1,7 @@
 aliases = [ ]
-dependencies = [ ]
+dependencies = [
+	"Object.create"
+]
 docs = "https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment"
 spec = "https://dom.spec.whatwg.org/#interface-documentfragment"
 notes = [ ]

--- a/polyfills/DocumentFragment/detect.js
+++ b/polyfills/DocumentFragment/detect.js
@@ -1,1 +1,8 @@
-'DocumentFragment' in self && self.DocumentFragment === document.createDocumentFragment().constructor
+'DocumentFragment' in self && (function () {
+	try {
+		new DocumentFragment();
+		return true;
+	} catch (_) {
+		return false;
+	}
+}())

--- a/polyfills/DocumentFragment/polyfill.js
+++ b/polyfills/DocumentFragment/polyfill.js
@@ -1,1 +1,8 @@
-self.DocumentFragment = document.createDocumentFragment().constructor;
+(function (global) {
+	global.DocumentFragment = function DocumentFragment() {
+		return document.createDocumentFragment();
+	};
+
+	var fragment = document.createDocumentFragment();
+	global.DocumentFragment.prototype = Object.create(fragment.constructor.prototype)
+}(self));

--- a/polyfills/DocumentFragment/prototype/append/polyfill.js
+++ b/polyfills/DocumentFragment/prototype/append/polyfill.js
@@ -1,4 +1,11 @@
 /* global _mutation */
-DocumentFragment.prototype.append = function append() {
-	this.appendChild(_mutation(arguments));
-};
+(function (global) {
+	var fragmentProto = document.createDocumentFragment().constructor.prototype;
+	fragmentProto.append = function append() {
+		this.appendChild(_mutation(arguments));
+	};
+
+	global.DocumentFragment.prototype.append = function append() {
+		this.appendChild(_mutation(arguments));
+	};
+}(self));

--- a/polyfills/DocumentFragment/prototype/prepend/polyfill.js
+++ b/polyfills/DocumentFragment/prototype/prepend/polyfill.js
@@ -1,4 +1,11 @@
 /* global _mutation */
-DocumentFragment.prototype.prepend = function prepend() {
-	this.insertBefore(_mutation(arguments), this.firstChild);
-};
+(function (global) {
+	var fragmentProto = document.createDocumentFragment().constructor.prototype;
+	fragmentProto.prepend = function prepend() {
+		this.insertBefore(_mutation(arguments), this.firstChild);
+	};
+
+	global.DocumentFragment.prototype.prepend = function prepend() {
+		this.insertBefore(_mutation(arguments), this.firstChild);
+	};
+}(self));

--- a/polyfills/DocumentFragment/tests.js
+++ b/polyfills/DocumentFragment/tests.js
@@ -1,6 +1,23 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
 
-it('is the DocumentFragment constructor', function () {
-	proclaim.equal(self.DocumentFragment, document.createDocumentFragment().constructor);
+it('has a working constructor', function () {
+	proclaim.doesNotThrow(function () {
+	new DocumentFragment();
+	});
+
+	proclaim.ok(!!(new DocumentFragment()));
+});
+
+// TODO : needs full test suite.
+// This had insufficient tests. Adding a simple test to check if the basics work.
+it('can be used to add elements to the document', function () {
+	var fragment = new DocumentFragment()
+
+	var el = document.createElement('div')
+	el.id = 'added-with-fragment';
+	fragment.appendChild(el)
+	document.body.appendChild(el);
+
+	proclaim.equal(el, document.getElementById('added-with-fragment'));
 });

--- a/polyfills/Object/seal/detect.js
+++ b/polyfills/Object/seal/detect.js
@@ -5,4 +5,4 @@
     } catch (err) {
         return false;
     }
-})
+}())

--- a/polyfills/Reflect/apply/detect.js
+++ b/polyfills/Reflect/apply/detect.js
@@ -1,1 +1,1 @@
-'apply' in self.Reflect
+self.Reflect && 'apply' in self.Reflect

--- a/polyfills/Reflect/construct/detect.js
+++ b/polyfills/Reflect/construct/detect.js
@@ -1,1 +1,1 @@
-'construct' in self.Reflect
+self.Reflect && 'construct' in self.Reflect

--- a/polyfills/Reflect/defineProperty/detect.js
+++ b/polyfills/Reflect/defineProperty/detect.js
@@ -1,1 +1,1 @@
-'defineProperty' in self.Reflect
+self.Reflect && 'defineProperty' in self.Reflect

--- a/polyfills/Reflect/deleteProperty/detect.js
+++ b/polyfills/Reflect/deleteProperty/detect.js
@@ -1,1 +1,1 @@
-'deleteProperty' in self.Reflect
+self.Reflect && 'deleteProperty' in self.Reflect

--- a/polyfills/Reflect/get/detect.js
+++ b/polyfills/Reflect/get/detect.js
@@ -1,1 +1,1 @@
-'get' in self.Reflect
+self.Reflect && 'get' in self.Reflect

--- a/polyfills/Reflect/getOwnPropertyDescriptor/detect.js
+++ b/polyfills/Reflect/getOwnPropertyDescriptor/detect.js
@@ -1,1 +1,1 @@
-'getOwnPropertyDescriptor' in self.Reflect
+self.Reflect && 'getOwnPropertyDescriptor' in self.Reflect

--- a/polyfills/Reflect/getPrototypeOf/detect.js
+++ b/polyfills/Reflect/getPrototypeOf/detect.js
@@ -1,1 +1,1 @@
-'getPrototypeOf' in self.Reflect
+self.Reflect && 'getPrototypeOf' in self.Reflect

--- a/polyfills/Reflect/has/detect.js
+++ b/polyfills/Reflect/has/detect.js
@@ -1,1 +1,1 @@
-'has' in self.Reflect
+self.Reflect && 'has' in self.Reflect

--- a/polyfills/Reflect/isExtensible/detect.js
+++ b/polyfills/Reflect/isExtensible/detect.js
@@ -1,1 +1,1 @@
-'isExtensible' in self.Reflect
+self.Reflect && 'isExtensible' in self.Reflect

--- a/polyfills/Reflect/ownKeys/detect.js
+++ b/polyfills/Reflect/ownKeys/detect.js
@@ -1,1 +1,1 @@
-'ownKeys' in self.Reflect
+self.Reflect && 'ownKeys' in self.Reflect

--- a/polyfills/Reflect/preventExtensions/detect.js
+++ b/polyfills/Reflect/preventExtensions/detect.js
@@ -1,1 +1,1 @@
-'preventExtensions' in self.Reflect
+self.Reflect && 'preventExtensions' in self.Reflect

--- a/polyfills/Reflect/set/detect.js
+++ b/polyfills/Reflect/set/detect.js
@@ -1,1 +1,1 @@
-'set' in self.Reflect
+self.Reflect && 'set' in self.Reflect

--- a/polyfills/Reflect/setPrototypeOf/detect.js
+++ b/polyfills/Reflect/setPrototypeOf/detect.js
@@ -1,1 +1,1 @@
-'setPrototypeOf' in self.Reflect
+self.Reflect && 'setPrototypeOf' in self.Reflect

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -163,12 +163,6 @@ async function testablePolyfills(isIE8, ua) {
           }).call(window));
         });
 
-        it('throws when called as a function', function() {
-          proclaim["throws"](function () {
-            (${config.detectSource})();
-          });
-        });
-
         ${await readFile(testFile)}
       });`;
       polyfilldata.push({

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -163,6 +163,12 @@ async function testablePolyfills(isIE8, ua) {
           }).call(window));
         });
 
+        it('throws when called as a function', function() {
+          proclaim["throws"](function () {
+            (${config.detectSource})();
+          });
+        });
+
         ${await readFile(testFile)}
       });`;
       polyfilldata.push({


### PR DESCRIPTION
resolves : https://github.com/Financial-Times/polyfill-library/issues/520

- add a [linter rule plugin](https://github.com/romainmenke/eslint-plugin-uncalled-iife) to detect uncalled `IIFE` in `detect.js`
- ~~verify that calling `detect.js` as a function throws~~
- fix some `detect.js` files
- fix `DocumentFragment` polyfill

----------

### eslint-plugin-uncalled-iife

I would have preferred to include a custom eslint rule in the `polyfill-library` repo but `eslint` does not support this.
The only way was to create a separate package containing the rule and publish it on npm.
This package is really small and I do not mind maintaining it when eslint introduces breaking changes.

There are cases that can't be caught this way. (named functions that aren't called)

<img width="962" alt="Screenshot 2020-10-16 at 11 15 30" src="https://user-images.githubusercontent.com/11521496/96248406-d5757100-0fab-11eb-8bfb-381cac767d70.png">

### DocumentFragment

Testing for uncalled `IIFE`'s exposed some issues with the `DocumentFragment ` polyfill.
I do not see how the previous code could have worked, but I might be overlooking something.
If you prefer, I can split this into two PR's.

### test for falsy

I tried adding a test that verifies that the code in `detect.js` returns something falsy in browsers that need the polyfill when the polyfill isn't loaded. In theory this would expose false positives/negatives. In practice this doesn't work :) Too many features would pass a `detect.js` but still need the polyfill. This then required adding a lot of exceptions which makes the test less useful.