### PR TITLE
fix : test director skips single feature

### DIFF
--- a/polyfills/AbortController/tests.js
+++ b/polyfills/AbortController/tests.js
@@ -1,5 +1,12 @@
 /* globals proclaim */
 
+beforeEach(function (done) {
+    // 
+    setTimeout(function () {
+        done();
+    }, 50);
+})
+
 describe('AbortSignal', function () {
     // Because these tests make use of the network, they can be unreliable and fail for reasons outside of the polyfills concern such as a Network Timeout.
     // We increase mocha timeout from 2 seconds to 10 seconds to cater for slow responses.
@@ -33,7 +40,7 @@ describe('AbortSignal', function () {
             setTimeout(function () {
                 controller.abort();
             }, 500);
-            fetch('https://httpstat.us/200?sleep=1000', {
+            fetch('/sleep?d=1000', {
                 signal: signal
             }).then(function () {
                 proclaim.isUndefined('Abort during fetch failed.');
@@ -49,7 +56,7 @@ describe('AbortSignal', function () {
             setTimeout(function () {
                 controller.abort();
             }, 500);
-            var request = new Request('https://httpstat.us/200?sleep=1000', {
+            var request = new Request('/sleep?d=1000', {
                 signal: signal
             });
             fetch(request).then(function () {
@@ -64,7 +71,7 @@ describe('AbortSignal', function () {
             var controller = new AbortController();
             controller.abort();
             var signal = controller.signal;
-            fetch('https://httpstat.us/200?sleep=1000', {
+            fetch('/sleep?d=1000', {
                 signal: signal
             }).then(function () {
                 proclaim.isUndefined('Abort during fetch failed.');
@@ -77,7 +84,7 @@ describe('AbortSignal', function () {
         it('fetch without aborting', function (done) {
             var controller = new AbortController();
             var signal = controller.signal;
-            fetch('https://httpstat.us/200?sleep=50', {
+            fetch('/sleep?d=50', {
                 signal: signal
             }).then(function () {
                 done();

--- a/polyfills/AbortController/tests.js
+++ b/polyfills/AbortController/tests.js
@@ -1,12 +1,5 @@
 /* globals proclaim */
 
-beforeEach(function (done) {
-    // 
-    setTimeout(function () {
-        done();
-    }, 50);
-})
-
 describe('AbortSignal', function () {
     // Because these tests make use of the network, they can be unreliable and fail for reasons outside of the polyfills concern such as a Network Timeout.
     // We increase mocha timeout from 2 seconds to 10 seconds to cater for slow responses.

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -126,6 +126,17 @@ app.get(
   }
 );
 
+app.get(
+  "/sleep",
+  async (request, response) => {
+    const duration = Math.max(Number.parseInt(request.query.d), 1000);
+    await new Promise((resolve) => setTimeout(resolve, duration));
+
+    response.status(200);
+    response.send("");
+  }
+);
+
 app.listen(port, () => console.log(`Test server listening on port ${port}!`));
 
 const testablePolyfillsCache = {};

--- a/test/polyfills/test-director.handlebars
+++ b/test/polyfills/test-director.handlebars
@@ -27,7 +27,7 @@
 			testedSuites: [],
 			uaString: 'unknown'
 		};
-		var queue = "{{features}}".split(',').slice(0,-1);
+		var queue = "{{features}}".split(',');
 		var runnerCompletedCount = 0;
 		var runnerTotalCount = queue.length;
 		var windowQueryString = "?includePolyfills={{{includePolyfills}}}&always={{{always}}}";


### PR DESCRIPTION
Handlebars was used before to turn the feature list into a comma separated string which resulted in a trailing comma.
`Array.join` is now used which does not have a trailing comma.

--------

ci fails in chrome on `AbortController`. This was never tested before as it is the first feature. (order is inversed twice I think)

--------

ci running now and seems to work better. Replace fetch calls to `https://httpstat.us/200?sleep=1000` with an internal "sleep" endpoint.

We had an issue some time ago where older OS's on Browserstack couldn't connect over `https` anymore because of the Sectigo cert expiry. My best guess is that this was the same issue.

Will run CI again to make sure it isn't just flacky and accidentally passing now.

--------

all green on this end