### PR TITLE
attempt at less flaky ResizeObserver tests

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -64,7 +64,6 @@ jobs:
         key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
-    - run: npm run build
     - name: Test on android
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=android
       env:
@@ -89,7 +88,6 @@ jobs:
         key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
-    - run: npm run build
     - name: Test on chrome
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=chrome
       env:
@@ -114,7 +112,6 @@ jobs:
         key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
-    - run: npm run build
     - name: Test on edge
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=edge
       env:
@@ -139,7 +136,6 @@ jobs:
         key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
-    - run: npm run build
     - name: Test on firefox
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=firefox
       env:
@@ -164,7 +160,6 @@ jobs:
         key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
-    - run: npm run build
     - name: Test on ios
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=ios
       env:
@@ -189,7 +184,6 @@ jobs:
         key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
-    - run: npm run build
     - name: Test on safari
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=safari
       env:

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -29,13 +29,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - name: Test on ie
@@ -51,13 +53,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -74,13 +78,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -97,13 +103,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -120,13 +128,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -143,13 +153,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -166,13 +178,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -30,7 +30,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
     - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - name: Test on ie
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=ie
       env:
@@ -45,6 +52,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
+    - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
     - name: Test on android
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=android
@@ -60,6 +75,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
+    - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
     - name: Test on chrome
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=chrome
@@ -75,6 +98,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
+    - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
     - name: Test on edge
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=edge
@@ -90,6 +121,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
+    - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
     - name: Test on firefox
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=firefox
@@ -105,6 +144,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
+    - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
     - name: Test on ios
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=ios
@@ -120,6 +167,14 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
+    - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
     - name: Test on safari
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=safari

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - name: Test on ie
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -80,7 +80,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -103,7 +103,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -126,7 +126,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -149,7 +149,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build
@@ -172,7 +172,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,15 +13,6 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
-    - name: env
-      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
-    - name: cache __dist
-      id: cache-dist
-      uses: actions/cache@v2
-      with:
-        path: polyfills/__dist
-        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
-      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run test-library

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,13 +13,15 @@ jobs:
     - uses: actions/setup-node@v2.1.2
       with:
         node-version: 12.x
+    - name: env
+      run: echo "commit-sha=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
     - run: npm ci
     - name: cache __dist
       id: cache-dist
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--$GITHUB_SHA
+        key: cache--dist--${{ env.commit-sha }}
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run test-library

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: polyfills/__dist
-        key: cache--dist--${{ env.GITHUB_SHA }}
+        key: cache--dist--$GITHUB_SHA
     - run: npm run build
       if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run test-library

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,5 +14,12 @@ jobs:
       with:
         node-version: 12.x
     - run: npm ci
+    - name: cache __dist
+      id: cache-dist
+      uses: actions/cache@v2
+      with:
+        path: polyfills/__dist
+        key: cache--dist--${{ env.GITHUB_SHA }}
     - run: npm run build
+      if: steps.cache-dist.outputs.cache-hit != 'true'
     - run: npm run test-library

--- a/polyfills/ResizeObserver/tests.js
+++ b/polyfills/ResizeObserver/tests.js
@@ -1,7 +1,12 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
 
-describe("ResizeObserver", function() {
+describe("ResizeObserver", function () {
+	// Extending the timeout and adding retries to reduce test flackiness.
+	// Failures can be emulated by running the tests and then quickly switching to another tab.
+	this.retries(2);
+	this.timeout(10 * 1000);
+
 	var delay = function(callback) {
 		setTimeout(function() {
 			callback()

--- a/test/polyfills/test-director.handlebars
+++ b/test/polyfills/test-director.handlebars
@@ -27,7 +27,7 @@
 			testedSuites: [],
 			uaString: 'unknown'
 		};
-		var queue = "{{features}}".split(',');
+		var queue = "{{features}}".split(',').slice(0,-1);
 		var runnerCompletedCount = 0;
 		var runnerTotalCount = queue.length;
 		var windowQueryString = "?includePolyfills={{{includePolyfills}}}&always={{{always}}}";

--- a/test/polyfills/test-director.handlebars
+++ b/test/polyfills/test-director.handlebars
@@ -27,7 +27,16 @@
 			testedSuites: [],
 			uaString: 'unknown'
 		};
-		var queue = "{{features}}".split(',').slice(0,-1);
+		var queue = "{{features}}".split(',');
+		var flackynessQueue = [];
+		for (var i = 0; i < queue.length; i++) {
+			const feature = queue[i];
+			for (let j = 0; j < 100; j++) {
+				flackynessQueue.push(feature);
+			}
+		}
+		queue = flackynessQueue;
+
 		var runnerCompletedCount = 0;
 		var runnerTotalCount = queue.length;
 		var windowQueryString = "?includePolyfills={{{includePolyfills}}}&always={{{always}}}";

--- a/test/polyfills/test-director.handlebars
+++ b/test/polyfills/test-director.handlebars
@@ -28,15 +28,6 @@
 			uaString: 'unknown'
 		};
 		var queue = "{{features}}".split(',');
-		var flackynessQueue = [];
-		for (var i = 0; i < queue.length; i++) {
-			const feature = queue[i];
-			for (let j = 0; j < 100; j++) {
-				flackynessQueue.push(feature);
-			}
-		}
-		queue = flackynessQueue;
-
 		var runnerCompletedCount = 0;
 		var runnerTotalCount = queue.length;
 		var windowQueryString = "?includePolyfills={{{includePolyfills}}}&always={{{always}}}";


### PR DESCRIPTION
Noticed that `ResizeObserver` tests sometimes fail. Did not find one root cause but is most likely caused by `requestAnimationFrame` not firing reliably (load on Browserstack vm?).

Extending timeouts and adding a few retries should reduce the number of failures.

--------------

Also added a per commit cache of the `polyfills/__dist` folder.
This is used only to share the build result between steps in a single run.

Full test suite now takes ±20 minutes (down from ±25 minutes)