### PR TITLE
add Polyfill specific cleanup tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "lint": "eslint polyfills lib tasks test",
-    "clean": "rimraf ./polyfills/__dist",
+    "clean": "rimraf ./polyfills/__dist && node tasks/clean",
     "build": "npm run clean && node tasks/updatesources && node tasks/buildsources/buildsources",
     "build-series": "npm run clean && node tasks/updatesources && node tasks/buildsources",
     "watch": "npm run clean && node tasks/updatesources && node tasks/buildsources/watchsource",

--- a/polyfills/Intl/DateTimeFormat/config.toml
+++ b/polyfills/Intl/DateTimeFormat/config.toml
@@ -45,3 +45,7 @@ samsung_mob = "*"
 module = "@formatjs/intl-datetimeformat"
 paths = [ "polyfill.umd.js" ]
 postinstall = "update.task.js"
+clean = [
+  "~locale",
+  "polyfill.js",
+]

--- a/polyfills/Intl/DisplayNames/config.toml
+++ b/polyfills/Intl/DisplayNames/config.toml
@@ -39,4 +39,7 @@ samsung_mob = "*"
 module = "@formatjs/intl-displaynames"
 paths = [ "polyfill.umd.js" ]
 postinstall = "update.task.js"
-
+clean = [
+  "~locale",
+  "polyfill.js",
+]

--- a/polyfills/Intl/NumberFormat/config.toml
+++ b/polyfills/Intl/NumberFormat/config.toml
@@ -44,4 +44,7 @@ samsung_mob = "*"
 module = "@formatjs/intl-numberformat"
 paths = [ "polyfill.umd.js" ]
 postinstall = "update.task.js"
-
+clean = [
+  "~locale",
+  "polyfill.js",
+]

--- a/polyfills/Intl/PluralRules/config.toml
+++ b/polyfills/Intl/PluralRules/config.toml
@@ -41,3 +41,7 @@ samsung_mob = "*"
 module = "@formatjs/intl-pluralrules"
 paths = [ "polyfill.umd.js" ]
 postinstall = "update.task.js"
+clean = [
+  "~locale",
+  "polyfill.js",
+]

--- a/polyfills/Intl/RelativeTimeFormat/config.toml
+++ b/polyfills/Intl/RelativeTimeFormat/config.toml
@@ -42,3 +42,7 @@ samsung_mob = "<6"
 module = "@formatjs/intl-relativetimeformat"
 paths = ["polyfill.umd.js"]
 postinstall = "update.task.js"
+clean = [
+  "~locale",
+  "polyfill.js",
+]

--- a/polyfills/Intl/getCanonicalLocales/config.toml
+++ b/polyfills/Intl/getCanonicalLocales/config.toml
@@ -30,3 +30,7 @@ samsung_mob = "*"
 [install]
 module = "@formatjs/intl-getcanonicallocales"
 paths = ["polyfill.umd.js"]
+clean = [
+  "~locale",
+  "polyfill.js",
+]

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const fs = require('graceful-fs');
+const path = require('path');
+const {promisify} = require('util');
+const glob = promisify(require('glob'));
+const TOML = require('@iarna/toml');
+const cwd = path.join(__dirname, '../');
+const globOptions = { cwd: cwd };
+const rimraf = require('rimraf');
+
+console.log('Cleaning polyfills...');
+glob('polyfills/**/config.toml', globOptions).then((files) => {
+	files.map((source) => {
+		try {
+			return Object.assign({ src: source }, TOML.parse(fs.readFileSync(source, 'utf-8')));
+		} catch (error) {
+			throw new Error('Failed on ' + source + '. Error: ' + error);
+		}
+	})
+	.filter((config) => {
+		return 'install' in config;
+	})
+	.forEach((config) => {
+		if (config.install.clean && config.install.clean.length > 0) {
+			const polyfillOutputFolder = path.dirname(config.src);
+
+			config.install.clean.forEach((toClean) => {
+				console.log(' * Removing ' + path.join(path.dirname(config.src), toClean));
+				rimraf.sync(path.resolve(polyfillOutputFolder, toClean));
+			});
+		}
+	});
+}).then(() => {
+	console.log('Polyfills cleaned successfully');
+}).catch((error) => {
+	console.log(error);
+	// eslint-disable-next-line unicorn/no-process-exit
+	process.exit(1);
+});


### PR DESCRIPTION
While testing `Intl` and switching between versions I had some errors because the update tasks add nested polyfills under `~locale`.

Example scenario :

- there is no change between versions in `polyfills/Intl/NumberFormat/polyfill.js`
- `polyfills/Intl/NumberFormat/~locale/af-NA/polyfill.js` does have a change between versions
- `tasks/updatesources.js` sees no change in `polyfills/Intl/NumberFormat/polyfill.js` and stops early
- `polyfills/Intl/NumberFormat/~locale/af-NA/polyfill.js` is never updated.

This change adds a `clean` entry to `config.toml` with a list of paths to remove per polyfill.

------------

note :

This is only an issue locally, not in CI as the files in question are ignored by git.
They never exist in CI but can exist locally.