### PR TITLE
fail tests on missing detect source with better feedback

### DIFF
--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -170,7 +170,7 @@ async function testablePolyfills(isIE8, ua) {
       const testSuite = `describe('${polyfill}', function() { 
         it('passes the feature detect', function() {
           proclaim.ok((function() {
-            return (${config.detectSource});
+            return (${config.detectSource || 'false'});
           }).call(window));
         });
 


### PR DESCRIPTION
Result when deleting `detect.js` for a polyfill : 

<img width="648" alt="Screenshot 2020-11-29 at 19 55 08" src="https://user-images.githubusercontent.com/11521496/100550810-c9ecb980-327c-11eb-809c-59ad1b3cbe65.png">

This should make it easier to spot this kind of issue : https://github.com/Financial-Times/polyfill-library/pull/913#issuecomment-734773203

There the test has a syntax error in older browsers when `detect.js` is missing (`return ();`).

[CI Results](https://github.com/romainmenke/polyfill-library/runs/1470577858)