### PR TITLE
Object fixes

### DIFF
--- a/polyfills/Object/create/tests.js
+++ b/polyfills/Object/create/tests.js
@@ -115,21 +115,25 @@ it("If the second argument is present and not undefined, add own properties to r
 	// proclaim.equal(result2, true);
 });
 
-it('Object.create', function () {
+describe('Object.create', function () {
 	var obj = {
 		q: 1
 	};
+
 	function has(x, xs){
-    var i = -1, l = xs.length >>> 0;
-    while (++i < l) if (x === xs[i]) return true;
-    return false;
-  }
+		var i = -1, l = xs.length >>> 0;
+		while (++i < l) if (x === xs[i]) return true;
+		return false;
+	}
+
 	function isObject(it) {
 		return it === Object(it);
 	}
+
 	function isPrototype(a, b) {
 		return {}.isPrototypeOf.call(a, b);
 	}
+
 	function getPropertyNames(object) {
 		var result = Object.getOwnPropertyNames(object);
 		// eslint-disable-next-line no-cond-assign
@@ -144,35 +148,80 @@ it('Object.create', function () {
 		}
 		return result;
 	}
-	proclaim.isFunction(Object.create);
-	proclaim.arity(Object.create, 2);
-	proclaim.hasName(Object.create, 'create');
-	proclaim.isNotEnumerable(Object, 'create');
-	proclaim.ok(isPrototype(obj, Object.create(obj)));
-	proclaim.ok(Object.create(obj).q === 1);
-	function fn() {
-		return this.a = 1;
-	}
-	proclaim.ok(Object.create(new fn) instanceof fn);
-	if ('getPrototypeOf' in Object) {
-		proclaim.ok(fn.prototype === Object.getPrototypeOf(Object.getPrototypeOf(Object.create(new fn))));
-	}
-	proclaim.ok(Object.create(new fn).a === 1);
-	proclaim.ok(Object.create({}, {
-		a: {
-			value: 42
-		}
-	}).a === 42);
-	obj = Object.create(null, {
-		w: {
-			value: 2
-		}
+
+	it('is a function', function () {
+		proclaim.isFunction(Object.create);
 	});
-	proclaim.ok(isObject(obj));
-	proclaim.ok(!('toString' in obj));
-	proclaim.ok(obj.w === 2);
+
+	it('has correct arity', function () {
+		proclaim.arity(Object.create, 2);
+	});
+
+	it('has the correct name', function () {
+		proclaim.hasName(Object.create, 'create');
+	});
+
+	it('is not enumerable', function () {
+		proclaim.isNotEnumerable(Object, 'create');
+	});
+
+	it('is prototype', function () {
+		proclaim.ok(isPrototype(obj, Object.create(obj)));
+	});
+
+	it('creates objects with properties', function () {
+		proclaim.ok(Object.create(obj).q === 1);
+	});
+
+	it('creates instances with properties', function () {
+		function fn() {
+			return this.a = 1;
+		}
+
+		proclaim.ok(Object.create(new fn).a === 1);
+	});
+
+	it('creates functions that are instances of itself', function () {
+		function fn() {
+			return this.a = 1;
+		}
+
+		proclaim.ok(Object.create(new fn) instanceof fn);
+	});
+
+	if ('getPrototypeOf' in Object) {
+		it('can get the prototype of', function () {
+			function fn() {
+				return this.a = 1;
+			}
+
+			proclaim.ok(fn.prototype === Object.getPrototypeOf(Object.getPrototypeOf(Object.create(new fn))));
+		});
+	}
 
 	if ('getOwnPropertyNames' in Object && 'getPrototypeOf' in Object) {
-		proclaim.deepEqual(getPropertyNames(Object.create(null)), []);
+		it('can get own property names', function () {
+			proclaim.deepEqual(getPropertyNames(Object.create(null)), []);
+		});
 	}
+
+	it('creates objects following the property descriptor map', function () {
+		proclaim.ok(Object.create({}, {
+			a: {
+				value: 42
+			}
+		}).a === 42);
+	});
+
+	it('creates correct object from property map alone', function () {
+		var obj2 = Object.create(null, {
+			w: {
+				value: 2
+			}
+		});
+
+		proclaim.ok(isObject(obj2));
+		proclaim.ok(!('toString' in obj2));
+		proclaim.ok(obj2.w === 2);
+	});
 });

--- a/polyfills/Object/create/tests.js
+++ b/polyfills/Object/create/tests.js
@@ -189,7 +189,23 @@ describe('Object.create', function () {
 		proclaim.ok(Object.create(new fn) instanceof fn);
 	});
 
-	if ('getPrototypeOf' in Object) {
+	if ('getPrototypeOf' in Object && (function () {
+		// supports getters (not IE8)
+		try {
+			var a = {};
+			Object.defineProperty(a, 't', {
+				configurable: true,
+				enumerable: false,
+				get: function () {
+					return true;
+				},
+				set: undefined
+			});
+			return !!a.t;
+		} catch (e) {
+			return false;
+		}
+	}())) {
 		it('can get the prototype of', function () {
 			function fn() {
 				return this.a = 1;

--- a/polyfills/Object/defineProperty/tests.js
+++ b/polyfills/Object/defineProperty/tests.js
@@ -69,26 +69,61 @@ describe('Basic functionality', function () {
 		proclaim.equal(object[property], value);
 	});
 
-	if ('create' in Object) {
-		it('Works with objects which have no prototype', function () {
-			var object = Object.create(null);
-			try {
-				Object.defineProperty(object, property, {
+	if (function () { // supports getters
+		try {
+			Object.defineProperty({}, property, {
 					configurable: true,
 					enumerable: true,
 					get: function () {
-						return value;
+						return 1;
 					}
 				});
-			} catch (e) {
-				if (e.message !== "Getters & setters cannot be defined on this javascript engine") {
-					throw e;
-				}
-			}
 
-			proclaim.equal(object[property], value);
-		});
+			return true;
+			} catch (_) {
+			return false;
+			}
+	}()) {
+		if ('create' in Object) {
+			it('Works with objects which have no prototype - getter', function () {
+				var object = Object.create(null);
+				try {
+					Object.defineProperty(object, property, {
+						configurable: true,
+						enumerable: true,
+						get: function () {
+							return value;
+						}
+					});
+				} catch (e) {
+					if (e.message !== "Getters & setters cannot be defined on this javascript engine") {
+						throw e;
+					}
+				}
+
+				proclaim.equal(object[property], value);
+			});
+		}
 	}
+
+	if ('create' in Object) {
+			it('Works with objects which have no prototype - value', function () {
+				var object = Object.create(null);
+				try {
+					Object.defineProperty(object, property, {
+						configurable: true,
+						enumerable: true,
+						value: value
+					});
+				} catch (e) {
+					if (e.message !== "Getters & setters cannot be defined on this javascript engine") {
+						throw e;
+					}
+				}
+
+				proclaim.equal(object[property], value);
+			});
+		}
 });
 
 describe('Error handling', function () {

--- a/polyfills/Object/entries/tests.js
+++ b/polyfills/Object/entries/tests.js
@@ -289,15 +289,24 @@ it('works as expected', function () {
 	proclaim.deepEqual(Object.entries(new String('qwe')), [['0', 'q'], ['1', 'w'], ['2', 'e']]);
 
 	if ('assign' in Object && 'create' in Object) {
-		proclaim.deepEqual(Object.entries(Object.assign(Object.create({
+		var assignedAndCreatedObj = Object.assign(Object.create({
 			q: 1,
 			w: 2,
 			e: 3
 		}), {
-				a: 4,
-				s: 5,
-				d: 6
-			})), [['a', 4], ['s', 5], ['d', 6]]);
+			a: 4,
+			s: 5,
+			d: 6
+		});
+
+		proclaim.deepEqual(
+			Object.entries(assignedAndCreatedObj),
+			[
+				['a', 4],
+				['s', 5],
+				['d', 6]
+			]
+		);
 	}
 	try {
 		proclaim.deepEqual(Function('return Object.entries({a: 1, get b(){delete this.c;return 2},c: 3})')(), [['a', 1], ['b', 2]]);

--- a/polyfills/Object/getPrototypeOf/polyfill.js
+++ b/polyfills/Object/getPrototypeOf/polyfill.js
@@ -16,8 +16,8 @@ CreateMethodProperty(Object, 'getPrototypeOf', function getPrototypeOf(object) {
 	if (proto || proto === null) {
 		return proto;
 	} else if (typeof object.constructor == 'function' && object instanceof object.constructor) {
-    return object.constructor.prototype;
-  } else if (object instanceof Object) {
+		return object.constructor.prototype;
+	} else if (object instanceof Object) {
 		return Object.prototype;
 	} else {
 		// Correctly return null for Objects created with `Object.create(null)`

--- a/polyfills/Object/keys/tests.js
+++ b/polyfills/Object/keys/tests.js
@@ -69,6 +69,37 @@ it('works with objects', function () {
 	}).length, 2);
 });
 
+if ('create' in Object) {
+  it('works with created objects', function () {
+    proclaim.equal(Object.keys(Object.create({})).length, 0);
+
+    proclaim.deepEqual(Object.keys(Object.create({}, {
+      foo: {
+        value: true,
+        enumerable: true
+      }
+    })), ['foo']);
+
+    proclaim.equal(Object.keys(Object.create({}, {
+      foo: {
+        value: true,
+        enumerable: true
+      }
+    })).length, 1);
+
+    proclaim.equal(Object.keys(Object.create({}, {
+      foo: {
+        value: true,
+        enumerable: true
+      },
+      bar: {
+        value: false,
+        enumerable: true
+      }
+    })).length, 2);
+  });
+}
+
 it('works with objects containing otherwise non-enumerable keys', function () {
 	proclaim.equal(Object.keys({
 		toString: function () {}

--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -34,16 +34,16 @@
 		return nGOPN(obj);
 	};
 	var gOPD = Object[GOPD];
-	var create = Object.create;
-	var keys = Object.keys;
+	var objectCreate = Object.create;
+	var objectKeys = Object.keys;
 	var freeze = Object.freeze || Object;
-	var defineProperty = Object[DP];
+	var objectDefineProperty = Object[DP];
 	var $defineProperties = Object[DPies];
 	var descriptor = gOPD(Object, GOPN);
 	var addInternalIfNeeded = function (o, uid, enumerable) {
 		if (!hOP.call(o, internalSymbol)) {
 			try {
-				defineProperty(o, internalSymbol, {
+				objectDefineProperty(o, internalSymbol, {
 					enumerable: false,
 					configurable: false,
 					writable: false,
@@ -56,7 +56,7 @@
 		o[internalSymbol]['@@' + uid] = enumerable;
 	};
 	var createWithSymbols = function (proto, descriptors) {
-		var self = create(proto);
+		var self = objectCreate(proto);
 		gOPN(descriptors).forEach(function (key) {
 			if (propertyIsEnumerable.call(descriptors, key)) {
 				$defineProperty(self, key, descriptors[key]);
@@ -65,7 +65,7 @@
 		return self;
 	};
 	var copyAsNonEnumerable = function (descriptor) {
-		var newDescriptor = create(descriptor);
+		var newDescriptor = objectCreate(descriptor);
 		newDescriptor.enumerable = false;
 		return newDescriptor;
 	};
@@ -101,18 +101,18 @@
 			}
 		};
 		try {
-			defineProperty(ObjectProto, uid, descriptor);
+			objectDefineProperty(ObjectProto, uid, descriptor);
 		} catch (e) {
 			ObjectProto[uid] = descriptor.value;
 		}
-		source[uid] = defineProperty(
+		source[uid] = objectDefineProperty(
 			Object(uid),
 			'constructor',
 			sourceConstructor
 		);
 		var description = gOPD(Symbol.prototype, 'description');
 		if (description) {
-			defineProperty(
+			objectDefineProperty(
 				source[uid],
 				'description',
 				description
@@ -129,19 +129,19 @@
 			prefix.concat(description || '', random, ++id)
 		);
 		};
-	var source = create(null);
+	var source = objectCreate(null);
 	var sourceConstructor = {value: Symbol};
 	var sourceMap = function (uid) {
 		return source[uid];
 		};
-	var $defineProperty = function defineProp(o, key, descriptor) {
+	var $defineProperty = function defineProperty(o, key, descriptor) {
 		var uid = '' + key;
 		if (onlySymbols(uid)) {
 			setDescriptor(o, uid, descriptor.enumerable ?
 				copyAsNonEnumerable(descriptor) : descriptor);
 			addInternalIfNeeded(o, uid, !!descriptor.enumerable);
 		} else {
-			defineProperty(o, key, descriptor);
+			objectDefineProperty(o, key, descriptor);
 		}
 		return o;
 	};
@@ -157,20 +157,20 @@
 	;
 
 	descriptor.value = $defineProperty;
-	defineProperty(Object, DP, descriptor);
+	objectDefineProperty(Object, DP, descriptor);
 
 	descriptor.value = $getOwnPropertySymbols;
-	defineProperty(Object, GOPS, descriptor);
+	objectDefineProperty(Object, GOPS, descriptor);
 
 	descriptor.value = function getOwnPropertyNames(o) {
 		return gOPN(o).filter(onlyNonSymbols);
 	};
-	defineProperty(Object, GOPN, descriptor);
+	objectDefineProperty(Object, GOPN, descriptor);
 
 	descriptor.value = function defineProperties(o, descriptors) {
 		var symbols = $getOwnPropertySymbols(descriptors);
 		if (symbols.length) {
-		keys(descriptors).concat(symbols).forEach(function (uid) {
+		objectKeys(descriptors).concat(symbols).forEach(function (uid) {
 			if (propertyIsEnumerable.call(descriptors, uid)) {
 			$defineProperty(o, uid, descriptors[uid]);
 			}
@@ -180,20 +180,20 @@
 		}
 		return o;
 	};
-	defineProperty(Object, DPies, descriptor);
+	objectDefineProperty(Object, DPies, descriptor);
 
 	descriptor.value = propertyIsEnumerable;
-	defineProperty(ObjectProto, PIE, descriptor);
+	objectDefineProperty(ObjectProto, PIE, descriptor);
 
 	descriptor.value = Symbol;
-	defineProperty(global, 'Symbol', descriptor);
+	objectDefineProperty(global, 'Symbol', descriptor);
 
 	// defining `Symbol.for(key)`
 	descriptor.value = function (key) {
 		var uid = prefix.concat(prefix, key, random);
 		return uid in ObjectProto ? source[uid] : setAndGetSymbol(uid);
 	};
-	defineProperty(Symbol, 'for', descriptor);
+	objectDefineProperty(Symbol, 'for', descriptor);
 
 	// defining `Symbol.keyFor(symbol)`
 	descriptor.value = function (symbol) {
@@ -204,7 +204,7 @@
 		void 0
 		;
 	};
-	defineProperty(Symbol, 'keyFor', descriptor);
+	objectDefineProperty(Symbol, 'keyFor', descriptor);
 
 	descriptor.value = function getOwnPropertyDescriptor(o, key) {
 		var descriptor = gOPD(o, key);
@@ -213,14 +213,15 @@
 		}
 		return descriptor;
 	};
-	defineProperty(Object, GOPD, descriptor);
+	objectDefineProperty(Object, GOPD, descriptor);
 
-	descriptor.value = function (proto, descriptors) {
+	descriptor.value = function create(proto, descriptors) {
 		return arguments.length === 1 || typeof descriptors === "undefined" ?
-		create(proto) :
+		objectCreate(proto) :
 		createWithSymbols(proto, descriptors);
 	};
-	defineProperty(Object, 'create', descriptor);
+
+	objectDefineProperty(Object, 'create', descriptor);
 
 	var strictModeSupported = (function(){ 'use strict'; return this; }).call(null) === null;
 	if (strictModeSupported) {
@@ -246,14 +247,14 @@
 			return (str === '[object String]' && onlySymbols(this)) ? '[object Symbol]' : str;
 		};
 	}
-	defineProperty(ObjectProto, 'toString', descriptor);
+	objectDefineProperty(ObjectProto, 'toString', descriptor);
 
 	setDescriptor = function (o, key, descriptor) {
 		var protoDescriptor = gOPD(ObjectProto, key);
 		delete ObjectProto[key];
-		defineProperty(o, key, descriptor);
+		objectDefineProperty(o, key, descriptor);
 		if (o !== ObjectProto) {
-			defineProperty(ObjectProto, key, protoDescriptor);
+			objectDefineProperty(ObjectProto, key, protoDescriptor);
 		}
 	};
 


### PR DESCRIPTION
# Fixes for Object

## IE8-11

- [x] use correct name for Object methods in Symbol polyfill [1]
- [x] skip `__proto__` in `Object.keys` when `Object.create` polyfill is detected [2]
- [x] use feature test in `defineProperty` tests for getter support [3]
- [x] split up tests into multipe `it`'s, this makes debugging easier [4]

## IE8

- [x] cannot get the prototype of the result of `Object.create(new fn)` [5]

Update : test skipped in IE8 with a check for getters support.

--------

Notes :

(1) Symbol polyfill wraps some Object methods but didn't set a correct name for the wrapper function.

(2) `Object.create` sets `__proto__` via assignement. This makes `__proto__` enumerable.
Unsure if this should be fixed in `Object.create` or `Object.keys`. (now patched in `Object.keys`).

(3) `Object.defineProperty` has a feature test for `Object.create` but actually needed a check for getters support.
Fixed the test and added more which do not require getters.

(4) Some tests had a lot of `proclaim...` statements, making it harder to determine why something failed.
Splitting these up helped.

(5) **still broken**

Somehow it is not possible to get the prototype of the result of `Object.create(new fn)`.
The same test does pass in modern browsers so I don't think the test is broken.

This test never ran before as it checks for `'getPrototypeOf' in Object` before running.
Any browser that has `getPrototypeOf` natively doesn't need the `Object.create` polyfill.

@JakeChampion if someone could look into this that would really help 🙂 

```js
function fn() {
	return this.a = 1;
}

proclaim.ok(fn.prototype === Object.getPrototypeOf(Object.getPrototypeOf(Object.create(new fn))));
```

<img width="420" alt="Screenshot 2020-12-05 at 11 02 30" src="https://user-images.githubusercontent.com/11521496/101241279-dcd81180-36f4-11eb-86de-b2aacc39a82d.png">
