### PR TITLE
Reflect fixes

### DIFF
--- a/polyfills/Reflect/defineProperty/tests.js
+++ b/polyfills/Reflect/defineProperty/tests.js
@@ -23,7 +23,12 @@ it('returns true if defining the property was a success', function () {
     proclaim.isTrue(Object.prototype.hasOwnProperty.call(o, 'a'));
 });
 
-if ('freeze' in Object) {
+if ('freeze' in Object && (function () {
+    // check for Object.freeze polyfill which doesn't really freeze things.
+    var frozen = Object.freeze({});
+    frozen.foo = true;
+    return (typeof frozen.foo === 'undefined');
+}())) {
     it('returns false if defining the property was not a success', function () {
         var o = {};
         Object.freeze(o);

--- a/polyfills/Reflect/deleteProperty/tests.js
+++ b/polyfills/Reflect/deleteProperty/tests.js
@@ -46,7 +46,12 @@ it('returns true if deleting property was a success', function () {
     proclaim.isTrue(Reflect.deleteProperty(o, 'a'));
 });
 
-if ('freeze' in Object) {
+if ('freeze' in Object && (function () {
+    // check for Object.freeze polyfill which doesn't really freeze things.
+    var frozen = Object.freeze({});
+    frozen.foo = true;
+    return (typeof frozen.foo === 'undefined');
+}())) {
     it('returns false if deleting property was not a success', function () {
         var o = {
             a: 1

--- a/polyfills/Reflect/get/tests.js
+++ b/polyfills/Reflect/get/tests.js
@@ -64,7 +64,7 @@ it('returns value from a receiver', function () {
 
 if ('create' in Object && function () { // supports getters
     try {
-        Object.defineProperty({}, property, {
+        Object.defineProperty({}, 'x', {
             configurable: true,
             enumerable: true,
             get: function () {

--- a/polyfills/Reflect/get/tests.js
+++ b/polyfills/Reflect/get/tests.js
@@ -62,7 +62,21 @@ it('returns value from a receiver', function () {
     }
 });
 
-if ('create' in Object) {
+if ('create' in Object && function () { // supports getters
+    try {
+        Object.defineProperty({}, property, {
+            configurable: true,
+            enumerable: true,
+            get: function () {
+                return 1;
+            }
+        });
+
+        return true;
+    } catch (_) {
+        return false;
+    }
+}()) {
     it('returns prototype property value using a receiver', function () {
         var o = {};
         var n = {

--- a/polyfills/Reflect/isExtensible/tests.js
+++ b/polyfills/Reflect/isExtensible/tests.js
@@ -21,7 +21,20 @@ it('returns true if object is extensible', function () {
     proclaim.isTrue(Reflect.isExtensible({}));
 });
 
-if ('preventExtensions' in Object) {
+if ('preventExtensions' in Object && (function () {
+    // check for Object.preventExtensions polyfill which doesn't really prevent anything.
+    var notExtensible = {};
+    Object.preventExtensions(notExtensible)
+
+    try {
+        Object.defineProperty(notExtensible, 'property1', {
+            value: 42
+        });
+        return false
+    } catch (_) {
+        return true
+    }
+}())) {
     it('returns false if object is not extensible', function () {
         var o = {};
         Object.preventExtensions(o);

--- a/polyfills/Reflect/preventExtensions/tests.js
+++ b/polyfills/Reflect/preventExtensions/tests.js
@@ -27,7 +27,20 @@ it('returns true even if the object already prevents extentions', function () {
     proclaim.isTrue(Reflect.preventExtensions(obj));
 });
 
-if ('isExtensible' in Object) {
+if ('isExtensible' in Object && 'preventExtensions' in Object && (function () {
+    // check for Object.preventExtensions polyfill which doesn't really prevent anything.
+    var notExtensible = {};
+    Object.preventExtensions(notExtensible)
+
+    try {
+        Object.defineProperty(notExtensible, 'property1', {
+            value: 42
+        });
+        return false
+    } catch (_) {
+        return true
+    }
+}())) {
     it('prevents extentions on target', function () {
         var o = {};
         Reflect.preventExtensions(o);

--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -82,7 +82,7 @@
 		var uid = '' + key;
 		return onlySymbols(uid) ? (
 			hOP.call(this, uid) &&
-			this[internalSymbol]['@@' + uid]
+			this[internalSymbol] && this[internalSymbol]['@@' + uid]
 		) : pIE.call(this, key);
 	};
 	var setAndGetSymbol = function (uid) {


### PR DESCRIPTION
_smaller change_

Reflect has a couple of tests for `freeze` and variants.
These now have better checks to detect polyfills for older browsers which don't really freeze anything.

There was one failure in `Reflect.get` caused by a missing check in `Symbol`

```diff
- this[internalSymbol]['@@' + uid]
+ this[internalSymbol] && this[internalSymbol]['@@' + uid]
```
