### PR TITLE
WeakMap fixes

### DIFF
--- a/polyfills/WeakMap/config.toml
+++ b/polyfills/WeakMap/config.toml
@@ -14,6 +14,7 @@ dependencies = [
   "_ESAbstract.Type",
   "_ESAbstract.SameValue",
   "Symbol",
+  "Symbol.toStringTag",
   "Array.isArray"
 ]
 license = "MIT"

--- a/polyfills/WeakMap/polyfill.js
+++ b/polyfills/WeakMap/polyfill.js
@@ -240,7 +240,13 @@
 
 	// 23.3.3.6 WeakMap.prototype [ @@toStringTag ]
 	// The initial value of the @@toStringTag property is the String value "WeakMap".
-	// This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+	// This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.	
+	Object.defineProperty(WeakMap.prototype, Symbol.toStringTag, {
+		configurable: true,
+		enumerable: false,
+		writable: false,
+		value: 'WeakMap'
+	});
 
 	// Polyfill.io - Safari 8 implements WeakMap.name but as a non-writable property, which means it would throw an error if we try and write to it here.
 	if (!('name' in WeakMap)) {


### PR DESCRIPTION
_another small one_

`WeakMap` has a check for `'toStringTag' in Symbol` in a test but no dependency on it.
Added the dependency and defined `WeakMap.prototype[Symbol.toStringTag]` in the polyfill.