### PR TITLE
isolate test runs with and without polyfill combinations

### DIFF
--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -99,18 +99,40 @@ const tunnelId =
   (process.env.CIRCLE_BUILD_NUM || process.env.NODE_ENV || "null") +
   "_" +
   new Date().toISOString();
-const jobs = browsers.map(browser => {
-  const capability = useragentToBrowserObject(browser);
-  return new TestJob(
-    browser,
-    url,
-    mode,
-    capability,
-    tunnelId,
-    testBrowserTimeout,
-    pollTick
-  );
+
+const capabilities = browsers.map(browser => {
+  return useragentToBrowserObject(browser);
 });
+
+const jobs = [
+  ...(capabilities.map(capability => {
+    return new TestJob(
+      browser,
+      url,
+      mode,
+      capability,
+      tunnelId,
+      testBrowserTimeout,
+      pollTick
+    );
+  })),
+  ...(capabilities.map(capability => {
+    return new TestJob(
+      browser,
+      url + '&polyfillCombinations=yes',
+      mode,
+      capability,
+      tunnelId,
+      testBrowserTimeout,
+      pollTick
+    );
+  }))
+];
+
+jobs.forEach((job) => {
+  console.log('will test with url :', job.url);
+});
+
 const tunnel = new Tunnel();
 
 const openTunnel = promisify(tunnel.start.bind(tunnel));

--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -212,10 +212,9 @@ const printProgress = (function() {
       }
       if (message) {
         out.push(
-          ` • Browser: ${_.padEnd(
-            job.name,
+          ` • Browser: ${job.name.padEnd(
             " ",
-            10
+            20
           )} Test config: ${job.configForLog} ${message}`
         );
       }

--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -212,9 +212,10 @@ const printProgress = (function() {
       }
       if (message) {
         out.push(
-          ` • Browser: ${job.name.padEnd(
+          ` • Browser: ${_.padEnd(
+            job.name,
             " ",
-            20
+            10
           )} Test config: ${job.configForLog} ${message}`
         );
       }

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -232,7 +232,7 @@ function createEndpoint(template) {
     response.status(200);
 
     if (shard) {
-      features = features.slice((shard - 1) * (features.length / 3), (shard) * (features.length / 3));
+      features = features.slice((shard - 1) * (features.length / 2), (shard) * (features.length / 2));
     }
 
     response.set({

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -69,7 +69,7 @@ app.get(
   async (request, response) => {
     const ua = request.get("User-Agent");
     const isIE8 = polyfillio.normalizeUserAgent(ua) === "ie/8.0.0";
-    const polyfillCombinations = request.query.polyfillCombinations || "no";
+    const polyfillCombinations = (request.query.polyfillCombinations || "no") === "yes";
     const feature = request.query.feature || "";
     const includePolyfills = request.query.includePolyfills || "no";
     const always = request.query.always || "no";

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -69,6 +69,7 @@ app.get(
   async (request, response) => {
     const ua = request.get("User-Agent");
     const isIE8 = polyfillio.normalizeUserAgent(ua) === "ie/8.0.0";
+    const polyfillCombinations = request.query.polyfillCombinations || "no";
     const feature = request.query.feature || "";
     const includePolyfills = request.query.includePolyfills || "no";
     const always = request.query.always || "no";
@@ -84,13 +85,14 @@ app.get(
       const features = polyfillsWithTests.map(polyfill => polyfill.feature);
       const parameters = {
         features: createPolyfillLibraryConfigFor(
-          feature ? feature : features.join(","),
+          (feature && !polyfillCombinations) ? feature : features.join(","),
           always === "yes"
         ),
         minify: false,
         stream: false,
         uaString: always === "yes" ? "other/0.0.0" : request.get("user-agent")
       };
+
       const bundle = await polyfillio.getPolyfillString(parameters);
       response.send(bundle);
     } else {
@@ -197,6 +199,7 @@ function createEndpoint(template) {
     const isIE8 = polyfillio.normalizeUserAgent(ua) === "ie/8.0.0";
     const feature = request.query.feature || "";
     const includePolyfills = request.query.includePolyfills || "no";
+    const polyfillCombinations = request.query.polyfillCombinations || "no";
     const always = request.query.always || "no";
 
     if (includePolyfills !== "yes" && includePolyfills !== "no") {
@@ -236,6 +239,7 @@ function createEndpoint(template) {
         requestedFeature: !!feature,
         features: features.map(f => f.feature).join(','),
         includePolyfills: includePolyfills,
+        polyfillCombinations: polyfillCombinations,
         always: always,
         afterTestSuite: `
         // During the test run, surface the test results in Browserstacks' preferred format

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -185,7 +185,17 @@ async function testablePolyfills(isIE8, ua) {
     }
   }
 
-  polyfilldata.sort(function(a, b) {
+  polyfilldata.sort(function (a, b) {
+    // console.clear() test must run first to preserve console output of other tests.
+    // to run first it must be last in the list.
+    if (a.feature === 'console.clear') {
+      return 1;
+    }
+
+    if (b.feature === 'console.clear') {
+      return -1;
+    }
+
     return a.feature > b.feature ? -1 : 1;
   });
 

--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -200,6 +200,7 @@ function createEndpoint(template) {
     const feature = request.query.feature || "";
     const includePolyfills = request.query.includePolyfills || "no";
     const polyfillCombinations = request.query.polyfillCombinations || "no";
+    const shard = request.query.shard || false;
     const always = request.query.always || "no";
 
     if (includePolyfills !== "yes" && includePolyfills !== "no") {
@@ -225,10 +226,14 @@ function createEndpoint(template) {
     }
 
     // Filter for querystring args
-    const features = feature
+    let features = feature
       ? polyfills.filter(polyfill => feature === polyfill.feature)
       : polyfills;
     response.status(200);
+
+    if (shard) {
+      features = features.slice((shard - 1) * (features.length / 3), (shard) * (features.length / 3));
+    }
 
     response.set({
       "Content-Type": "text/html; charset=utf-8"

--- a/test/polyfills/test-director.handlebars
+++ b/test/polyfills/test-director.handlebars
@@ -30,7 +30,7 @@
 		var queue = "{{features}}".split(',');
 		var runnerCompletedCount = 0;
 		var runnerTotalCount = queue.length;
-		var windowQueryString = "?includePolyfills={{{includePolyfills}}}&always={{{always}}}";
+		var windowQueryString = "?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}";
 		var timeout = 30000;
 		var timeoutMaxRetries = 2;
 		var timeoutRetryCount = 0;

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -20,11 +20,12 @@ module.exports = class TestJob {
     capability,
     sessionName,
     testBrowserTimeout,
-    pollTick
+    pollTick,
+    polyfillCombinations,
+    shard
   ) {
     this.name = name;
     this.mode = mode;
-    this.url = url;
     this.results = undefined;
     this.lastUpdateTime = 0;
     this.duration = 0;
@@ -46,6 +47,17 @@ module.exports = class TestJob {
     this.pollTick = pollTick;
     this.setState("ready");
     this.runCount = 0;
+
+    this.url = url;
+    if (polyfillCombinations) {
+      this.polyfillCombinations = true;
+      this.url = this.url + 'polyfillCombinations=yes';
+    }
+
+    if (shard) {
+      this.shard = shard;
+      this.url = this.url + `shard=${shard}`;
+    }
   }
 
   async pollForResults() {
@@ -157,5 +169,9 @@ module.exports = class TestJob {
         : [],
       testedSuites: [...this.results.testedSuites]
     };
+  }
+
+  get configForLog() {
+    return `${this.mode.padEnd(" ", 8)} / ${(this.polyfillCombinations ? 'combined' : '').padEnd(" ", 8)} / ${(this.shard ? 'shard ' + this.shard : 'shard n/a').padEnd(" ", 8)}`;
   }
 };

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -172,6 +172,6 @@ module.exports = class TestJob {
   }
 
   get configForLog() {
-    return `${this.mode.padEnd(" ", 8)} / ${(this.polyfillCombinations ? 'combined' : '').padEnd(" ", 8)} / ${(this.shard ? 'shard ' + this.shard : 'shard n/a').padEnd(" ", 8)}`;
+    return `${this.mode.padEnd(" ", 8)} / ${(this.polyfillCombinations ? 'combined' : '        ')} / ${(this.shard ? 'shard ' + this.shard + '  ' : 'shard n/a')}`;
   }
 };

--- a/test/polyfills/test-job.js
+++ b/test/polyfills/test-job.js
@@ -51,12 +51,12 @@ module.exports = class TestJob {
     this.url = url;
     if (polyfillCombinations) {
       this.polyfillCombinations = true;
-      this.url = this.url + 'polyfillCombinations=yes';
+      this.url = this.url + '&polyfillCombinations=yes';
     }
 
     if (shard) {
       this.shard = shard;
-      this.url = this.url + `shard=${shard}`;
+      this.url = this.url + `&shard=${shard}`;
     }
   }
 

--- a/test/polyfills/test-runner.handlebars
+++ b/test/polyfills/test-runner.handlebars
@@ -6,7 +6,7 @@
 	<title>Mocha test suite for polyfill-library</title>
 
 	 <link rel="stylesheet" type="text/css" href="/mocha.css">
-	<script src="/polyfill.js?includePolyfills={{{includePolyfills}}}&always={{{always}}}&feature={{features}}"></script>
+	<script src="/polyfill.js?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}&feature={{features}}"></script>
 	<script src="/mocha.js"></script>
 	<script src="/proclaim.js"></script>
 	<script>mocha.setup('bdd');</script>


### PR DESCRIPTION
The current way of testing where only the needed polyfills are loaded must remain.
This tests if dependencies are correctly configured. Loading all polyfills for a browser would make it impossible to verify dependencies in a polyfill config.

IE8 also runs out of memory when loading all polyfills needed for IE8 on each test.

---------------

This change adds a new range of test jobs :
- Each browser now has at least 2 jobs.
One with and one without all polyfills in combination.
- IE8 and IE9 shard their tests.

result :
- we keep the original way of testing
- IE8 no longer runs out of memory when loading all polyfills
- IE9 was starting to struggle towards the end, splitting them up as a precaution.

This change does make CI slower again 🙁 
But running more tests just takes more time.

Run example : 

https://github.com/romainmenke/polyfill-library/runs/1506165325
This is from a branch which already contains all the other fixes but has `Symbol.prototype.description` removed.