### PR TITLE
fix URL polyfill by no longer overwriting it in the Blob polyfill

### DIFF
--- a/polyfills/Blob/polyfill.js
+++ b/polyfills/Blob/polyfill.js
@@ -61,7 +61,7 @@
 			FileException.prototype[file_ex_codes[file_ex_code]] = file_ex_code + 1;
 		}
 		// Polyfill URL
-		if (!real_URL.createObjectURL) {
+		if (!view.URL) {
 			URL = view.URL = function (uri) {
 				var
 					uri_info = document.createElementNS("http://www.w3.org/1999/xhtml", "a"),
@@ -78,6 +78,7 @@
 				return uri_info;
 			};
 		}
+
 		URL.createObjectURL = function (blob) {
 			var
 				type = blob.type,

--- a/polyfills/Blob/tests.js
+++ b/polyfills/Blob/tests.js
@@ -190,4 +190,47 @@ describe('Blob', function () {
 		proclaim.equal(blob1.type, '');
 		proclaim.equal(blob2.type, 'a');
 	});
+
+	it('can be converted to an object url', function () {
+		var blob = new Blob(['test']);
+		var blobURL = URL.createObjectURL(blob);
+
+		proclaim.ok(
+			blobURL.indexOf('data:') === 0 ||
+			blobURL.indexOf('blob:') === 0
+		);
+	});
+
+	it('object url has "null" origin', function () {
+		var blob = new Blob(['test']);
+		var blobURL = URL.createObjectURL(blob);
+
+		proclaim.ok(
+			blobURL.origin == null
+		);
+	});
+
+	if ('fetch' in self) {
+		it.skip('object url can be fetched', function (done) {
+			var blob = new Blob(['test']);
+			var blobURL = URL.createObjectURL(blob);
+
+			try {
+				fetch(blobURL).then(function (resp) {
+					if (resp.status !== 200) {
+						throw new Error('unexpected status code ' + resp.status);
+					}
+
+					return resp.text();
+				}).then(function (text) {
+					proclaim.equal(text, 'test');
+					done();
+				})["catch"](function (err1) {
+					done(err1);
+				});
+			} catch (err2) {
+				done(err2);
+			}
+		});
+	}
 });

--- a/polyfills/URL/polyfill.js
+++ b/polyfills/URL/polyfill.js
@@ -391,6 +391,10 @@
         },
         origin: {
           get: function () {
+            if (this.protocol.toLowerCase() === "data:") {
+              return null
+            }
+
             if ('origin' in instance) return instance.origin;
             return this.protocol + '//' + this.host;
           },

--- a/polyfills/fetch/tests.js
+++ b/polyfills/fetch/tests.js
@@ -1,0 +1,8 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+// Minimal test to ensure that fetch is included in CI
+// TODO : real tests
+it('exists', function () {
+	proclaim.ok('fetch' in self);
+});


### PR DESCRIPTION
The Blob polyfill also wrapped the URL polyfill.
Added tests for any functionality that was touched and modified the polyfill.

Also added a minimal test for `fetch`.
This makes it available in combination tests.