### PR TITLE
fix unterminated polyfills.

### DIFF
--- a/polyfills/DOMTokenList/prototype/replace/polyfill.js
+++ b/polyfills/DOMTokenList/prototype/replace/polyfill.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
 	var classList = document.createElement('div').classList;
 	classList && (classList.constructor.prototype.replace =
 		function (token, newToken) {
@@ -37,4 +37,4 @@
 			return true;
 		}
 	);
-})()
+})();

--- a/polyfills/_ESAbstract/GetSubstitution/polyfill.js
+++ b/polyfills/_ESAbstract/GetSubstitution/polyfill.js
@@ -70,4 +70,4 @@
 		// 12. Return result.
 		return result;
 	};
-}())
+}());


### PR DESCRIPTION
When the `DOMTokenList.prototype.replace` was followed in the bundle by another IIFE polyfill it would throw this error :

`Uncaught TypeError: (intermediate value)(...) is not a function`

[spec](https://www.ecma-international.org/ecma-262/5.1/#sec-7.9)

```js
// DOMTokenList.prototype.replace
(function () {
 console.log('hello');
})()

// Other polyfill with IIFE pattern
(function() {
  console.log('world!');
}());

// 🔥 
```

------------

Found the same issue in `_ESAbstract/GetSubstitution`