### PR TITLE
add "es2015" to the aliases of String.fromCodePoint

### DIFF
--- a/polyfills/String/fromCodePoint/config.toml
+++ b/polyfills/String/fromCodePoint/config.toml
@@ -1,4 +1,4 @@
-aliases = [ "es6" ]
+aliases = [ "es6", "es2015" ]
 dependencies = [
   "_ESAbstract.CreateMethodProperty",
   "_ESAbstract.ToNumber",


### PR DESCRIPTION
I think there should be `"es2015"` in the `aliases` of `String.fromCodePoint`, what do you think?
Please confirm.