### PR TITLE
Update smoothscroll detect logic

### DIFF
--- a/polyfills/smoothscroll/detect.js
+++ b/polyfills/smoothscroll/detect.js
@@ -1,4 +1,18 @@
-('document' in self && 'documentElement' in self.document && 'style' in self.document.documentElement && 'scrollBehavior' in document.documentElement.style) && (function () {
+(function () {
+  var supportsScrollBehaviorViaCss = ('document' in self && 'documentElement' in self.document && 'style' in self.document.documentElement && 'scrollBehavior' in document.documentElement.style);
+
+  if (supportsScrollBehaviorViaCss) {
+    return true;
+  }
+  
+  var hasNativeScrollToFunction = Element.prototype.scrollTo && Element.prototype.scrollTo.toString().indexOf('[native code]') > -1;
+  // If a browser has a native scrollTo implementation but does not support scroll-behavior via CSS, it is not possible to detect during runtime
+  // whether smooth scrolling is supported. An example browser which has native scrollTo but does not support smooth scrolling is Safari.
+  // In this situation we instead return false because it is very likely the polyfill is required.
+  if (hasNativeScrollToFunction) {
+    return false;
+  }
+
   try {
     var supportsSmoothScroll = false;
 

--- a/polyfills/smoothscroll/detect.js
+++ b/polyfills/smoothscroll/detect.js
@@ -1,4 +1,4 @@
-('document' in self && 'documentElement' in self.document && 'style' in self.document.documentElement && 'scrollBehavior' in document.documentElement.style) || (function () {
+('document' in self && 'documentElement' in self.document && 'style' in self.document.documentElement && 'scrollBehavior' in document.documentElement.style) && (function () {
   try {
     var supportsSmoothScroll = false;
 


### PR DESCRIPTION
I noticed the `smoothscroll` polyfill wasn't patching properly in Safari when using the polyfill-service. The first part of the detect logic returns `false` (indicating the need for the polyfill), while the second returns `true`. However, when wrapping the detect logic with `!()` for the `?flags=gated` case, it evaluates to `false` due to the `||` operator. 

<img width="860" alt="Screen Shot 2020-12-15 at 11 16 06 PM" src="https://user-images.githubusercontent.com/13597875/102316918-9fad2400-3f2b-11eb-89fc-d0942c4ca41c.png">

This PR updates the logic from `||` to `&&`.

Please let me know if there is any more info I can provide or things I forgot to address with this PR.