### PR TITLE
Update targeting for TypedArray polyfills

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,7 @@ polyfills/__dist/**
 # We do not ignore the config.json, detect.js or tests.js
 # because we do control their implementation.
 
-polyfills/_TypedArray/polyfill.js
+polyfills/ArrayBuffer/polyfill.js
 polyfills/atob/polyfill.js
 polyfills/AudioContext/polyfill.js
 polyfills/EventSource/polyfill.js

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ polyfills/MutationObserver/polyfill.js
 polyfills/ResizeObserver/polyfill.js
 polyfills/UserTiming/polyfill.js
 polyfills/WebAnimations/polyfill.js
-polyfills/_TypedArray/polyfill.js
+polyfills/ArrayBuffer/polyfill.js
 polyfills/atob/polyfill.js
 polyfills/fetch/polyfill.js
 polyfills/HTMLTemplateElement/polyfill.js

--- a/polyfills/ArrayBuffer/config.toml
+++ b/polyfills/ArrayBuffer/config.toml
@@ -8,8 +8,7 @@ aliases = [
   "Uint32Array",
   "Float32Array",
   "Float64Array",
-  "DataView",
-  "ArrayBuffer"
+  "DataView"
 ]
 license = "MIT"
 repo = "https://github.com/inexorabletash/polyfill"
@@ -36,4 +35,3 @@ samsung_mob = "*"
 [install]
 module = "js-polyfills"
 paths = [ "typedarray.js" ]
-

--- a/polyfills/HTMLCanvasElement/prototype/toBlob/config.toml
+++ b/polyfills/HTMLCanvasElement/prototype/toBlob/config.toml
@@ -2,7 +2,7 @@
 aliases = [ "HTMLCanvasElement.protoype.toBlob" ]
 dependencies = [
   "_ESAbstract.CreateMethodProperty",
-  "_TypedArray",
+  "ArrayBuffer",
   "atob",
   "Blob"
 ]
@@ -18,4 +18,3 @@ safari = "<11"
 ie = ">=10"
 opera = "<37"
 ios_saf = "<11"
-

--- a/polyfills/Math/fround/config.toml
+++ b/polyfills/Math/fround/config.toml
@@ -1,5 +1,5 @@
 aliases = [ "es6", "es2015" ]
-dependencies = [ "_ESAbstract.CreateMethodProperty", "_TypedArray" ]
+dependencies = [ "_ESAbstract.CreateMethodProperty", "ArrayBuffer" ]
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround"
 spec = "https://tc39.github.io/ecma262/#sec-math.fround"
 
@@ -17,4 +17,3 @@ op_mob = "*"
 op_mini = "*"
 safari = "<8"
 firefox_mob = "<26"
-

--- a/test/node/lib/test-index.js
+++ b/test/node/lib/test-index.js
@@ -179,9 +179,9 @@ describe("polyfillio", function () {
 				},
 				uaString: "ie/9"
 			});
-			
+
 			assert.deepEqual(setsToArrays(noExcludes), {
-				"Math.fround": { 
+				"Math.fround": {
 					flags: [],
 					dependencyOf: [],
 					aliasOf: []
@@ -191,21 +191,21 @@ describe("polyfillio", function () {
 					dependencyOf: ["Math.fround"],
 					aliasOf: []
 				},
-				_TypedArray: {
-					flags: [], 
+				ArrayBuffer: {
+					flags: [],
 					dependencyOf: ["Math.fround"],
 					aliasOf: []
 				}
 			});
-			
+
 			const excludes = await polyfillio.getPolyfills({
 				features: {
 					"Math.fround": {}
 				},
-				excludes: ["_TypedArray", "non-existent-feature"],
+				excludes: ["ArrayBuffer", "non-existent-feature"],
 				uaString: "ie/9"
 			});
-			
+
 			assert.deepEqual(setsToArrays(excludes), {
 				"Math.fround": {
 					flags: [],


### PR DESCRIPTION
The numbers were taken from MDN -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#Browser_compatibility

Fixes https://github.com/Financial-Times/polyfill-library/issues/667