### PR TITLE
make sure errors contain useful messages

### DIFF
--- a/tasks/buildsources/buildsources-child-proc.js
+++ b/tasks/buildsources/buildsources-child-proc.js
@@ -85,9 +85,20 @@ async function handleList(options) {
 			polyfill.sources = {}; // No need to communicate this back to the parent process, output files have been written.
 			polyfills.push(polyfill);
 		} catch (error) {
+			if (error instanceof Error) {
+				throw {
+					name: "Build error",
+					message: `Error while building: ${path.relative(source, absolute)}`,
+					error: {
+						message: error.message,
+						error: error
+					}
+				};
+			}
+			
 			throw {
 				name: "Build error",
-				message: `Error handling ${path.relative(source, absolute)}`,
+				message: `Error while building: ${path.relative(source, absolute)}`,
 				error
 			};
 		}


### PR DESCRIPTION
see : https://github.com/Financial-Times/polyfill-library/pull/945#issuecomment-746533357

- `Error handling ...` was confusing. 
- `Error` instances where logged as `{}`

```
{
  name: 'Build error',
  message: 'Error while building: _TypedArray',
  error: {
    message: 'Internal polyfill called _TypedArray is not targeting all supported browsers correctly. It should be: \n' +
      'android = "*"\n' +
      'bb = "*"\n' +
      'chrome = "*"\n' +
      'edge = "*"\n' +
      'edge_mob = "*"\n' +
      'firefox = "*"\n' +
      'firefox_mob = "*"\n' +
      'ie = "*"\n' +
      'ie_mob = "*"\n' +
      'ios_chr = "*"\n' +
      'ios_saf = "*"\n' +
      'op_mini = "*"\n' +
      'op_mob = "*"\n' +
      'opera = "*"\n' +
      'safari = "*"\n' +
      'samsung_mob = "*"\n',
    error: {}
  }
}
```