### PR TITLE
fix test polyfill timeout

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -23,7 +23,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     needs: [check-for-other-pull-requests-running-this-workflow]
     strategy:
       max-parallel: 1
@@ -63,6 +62,7 @@ jobs:
     - name: Test ${{ matrix.browser }}
       run: node ./test/polyfills/server.js & node ./test/polyfills/remotetest.js targeted director browser=${{ matrix.browser }}
       if: steps.witness.outputs.cache-hit != 'true'
+      timeout-minutes: 30
       env:
         BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
I thought the timeout would apply to each run in the matrix, but it is a "global" timeout.
https://github.com/Financial-Times/polyfill-library/actions/runs/434646466