### PR TITLE
Update config.toml

### DIFF
--- a/polyfills/DOMRect/config.toml
+++ b/polyfills/DOMRect/config.toml
@@ -8,7 +8,7 @@ docs = "https://developer.mozilla.org/en-US/docs/Web/API/DOMRect"
 [browsers]
 ie = "9 - *"
 ie_mob = "9 - *"
-chrome = "<60"
+chrome = "<61"
 ios_chr = "<10.1"
 safari = "<10.1"
 ios_saf = "<10.1"


### PR DESCRIPTION
Chrome 60 needs DOMRect polyfill

https://github.com/romainmenke/web-tests/blob/a1fc6fc233baf0de2719a2e7684b729bb593430c/geometry-1/3.DOMRect/results.babel_webpack.json#L394-L409
https://developer.mozilla.org/en-US/docs/Web/API/DOMRect#browser_compatibility