### PR TITLE
Add alias for web animations polyfill

### DIFF
--- a/polyfills/WebAnimations/config.toml
+++ b/polyfills/WebAnimations/config.toml
@@ -1,9 +1,5 @@
 aliases = [
-  "Animation",
-  "AnimationTimeline",
-  "Element.prototype.animate",
-  "KeyframeEffect",
-  "document.timeline"
+  "Element.prototype.animate"
 ]
 dependencies = [ ]
 license = "Apache-2.0"

--- a/polyfills/WebAnimations/config.toml
+++ b/polyfills/WebAnimations/config.toml
@@ -1,3 +1,10 @@
+aliases = [
+  "Animation",
+  "AnimationTimeline",
+  "Element.prototype.animate",
+  "KeyframeEffect",
+  "document.timeline"
+]
 dependencies = [ ]
 license = "Apache-2.0"
 spec = "https://w3c.github.io/web-animations/"


### PR DESCRIPTION
~Sourced from the spec : https://www.w3.org/TR/web-animations-1/#programming-interface~
~Verified in the source that these features are polyfilled : https://github.com/web-animations/web-animations-js~

Only added `Element.prototype.animate` based on [this table](https://github.com/web-animations/web-animations-js/blob/dev/docs/experimental.md)