### PR TITLE
Todd gandee/issue 2604/fix intl datetimeformat

### DIFF
--- a/polyfills/Intl/DateTimeFormat/config.toml
+++ b/polyfills/Intl/DateTimeFormat/config.toml
@@ -44,7 +44,10 @@ samsung_mob = "*"
 
 [install]
 module = "@formatjs/intl-datetimeformat"
-paths = [ "polyfill.umd.js" ]
+paths = [
+  "polyfill.umd.js",
+  "add-all-tz.js"
+]
 postinstall = "update.task.js"
 clean = [
   "~locale",

--- a/polyfills/Intl/DateTimeFormat/tests.js
+++ b/polyfills/Intl/DateTimeFormat/tests.js
@@ -4178,3 +4178,12 @@ it("should fix dayperiod bug in chrome", function () {
   proclaim.ok(dayPeriod);
   proclaim.notOk(dayperiod);
 });
+
+it("should have timezone name", function () {
+  var timeZoneObject = Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    timeZoneName: 'long'
+  }).formatToParts(0)
+    .find(function(object) { return object.type === 'timeZoneName';});
+  proclaim.equal(timeZoneObject.value, 'Eastern Standard Time');
+});


### PR DESCRIPTION
**[Intl.DateTimeFormat  -  Issue 2604](https://github.com/Financial-Times/polyfill-service/issues/2604)**

Timezone Data is not in the Polyfill

Background information
I am using the Intl.DateTimeFormat to label and format with a IANA timezone. I was getting `RangeError` in Bugsnag and it was coming from Safari 10. I thought it was covered in my Polyfill package, but it wasn't

Implementation summary
Added the `all-tz-data.js` to the config path
Added a test to cover the timezone label, it's the easiest test for timezone.

Before & after
Before testing in Safari
![image](https://user-images.githubusercontent.com/1489134/116637298-7c5ea080-a931-11eb-82a2-031da6b5aab9.png)

After just adding the test
![image](https://user-images.githubusercontent.com/1489134/116637418-e70fdc00-a931-11eb-81df-a74a74307ff8.png)

After adding the path in the config and building
![image](https://user-images.githubusercontent.com/1489134/116637701-9e0c5780-a932-11eb-8b37-6142de9bc81f.png)



