### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3676,9 +3676,9 @@
           "dev": true
         },
         "ua-parser-js": {
-          "version": "0.7.23",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-          "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+          "version": "0.7.28",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+          "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
           "dev": true
         },
         "wrap-ansi": {
@@ -5941,9 +5941,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
       "dev": true
     },
     "uglify-js": {


### PR DESCRIPTION
### Updated (2)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [ua-parser-js](https://npm.im/ua-parser-js) | `0.7.23` → `0.7.28` | [github](https://github.com/faisalman/ua-parser-js) | **[High]** Regular Expression Denial of Service ([ref](https://npmjs.com/advisories/1679)) |
| [ua-parser-js](https://npm.im/ua-parser-js) | `0.7.21` → `0.7.28` | [github](https://github.com/faisalman/ua-parser-js) | **[High]** Regular Expression Denial of Service ([ref](https://npmjs.com/advisories/1679)) |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.11**.