### PR TITLE
better url logs for failing ci tests

### DIFF
--- a/test/polyfills/remotetest.js
+++ b/test/polyfills/remotetest.js
@@ -24,6 +24,7 @@ const TestJob = require("./test-job");
 const Tunnel = require("browserstack-local").Local;
 const modifiedPolyfillsWithTests = require('../utils/modified-polyfills-with-tests').modifiedPolyfillsWithTests;
 const UA = require("@financial-times/polyfill-useragent-normaliser");
+const { URL } = require('url');
 
 // Grab all the browsers from BrowserStack which are officially supported by the polyfil service.
 const TOML = require("@iarna/toml");
@@ -402,11 +403,14 @@ async function main() {
         for (const job of jobs) {
           if (job.results && job.results.tests) {
             for (const test of job.results.tests) {
+              const failingTestURL = new URL(url);
+              failingTestURL.searchParams.delete('feature');
+
               console.log(" - " + job.name + ":");
               console.log("    -> " + test.name);
               console.log(
                 "       " +
-                url.replace("http://bs-local.com:9876/", "http://bs-local.com:9876/test") +
+                failingTestURL.toString().replace("http://bs-local.com:9876/", "http://bs-local.com:9876/test") +
                 "&feature=" +
                 test.failingSuite
               );


### PR DESCRIPTION
```diff
Failures:
 - ie/8.0:
    -> document.elementsFromPoint document.elementsFromPoint returns all the elements at the specified coordinates
-      http://bs-local.com:9876/test?includePolyfills=yes&always=no&feature=document.elementsFromPoint&feature=document.elementsFromPoint
+      http://bs-local.com:9876/test?includePolyfills=yes&always=no&feature=document.elementsFromPoint
       p deepStrictEqual p,div,body,html
```

Tested on node 8 -> 16

------

duplicate `feature` param bug was introduced in https://github.com/Financial-Times/polyfill-library/pull/997