### PR TITLE
ensure Map and Set iterators are polyfilled

### DIFF
--- a/polyfills/Array/from/config.toml
+++ b/polyfills/Array/from/config.toml
@@ -32,17 +32,22 @@ dependencies = [
 spec = "https://tc39.github.io/ecma262/#sec-array.from"
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from"
 
-[browsers]
-chrome = "<45"
-firefox = "4 - 31"
-ie = "6 - 11"
-ie_mob = "10 - *"
-opera = "<32"
-op_mini = "*"
-safari = "<9"
-firefox_mob = "<32"
-android = "*"
-ios_saf = "<9"
-samsung_mob = "<5"
-bb = "10 - *"
+notes = [
+  "Array.from polyfill must be included in all browser versions that require Symbol.iterator"
+]
 
+[browsers]
+android = "*"
+bb = "10 - *"
+chrome = "<49"
+edge = "<13"
+edge_mob = "<13"
+firefox = "4 - 36"
+firefox_mob = "<32"
+ie = "*"
+ie_mob = "*"
+ios_saf = "<9"
+op_mini = "*"
+opera = "<37"
+safari = "<9"
+samsung_mob = "<5"

--- a/polyfills/Array/from/detect.js
+++ b/polyfills/Array/from/detect.js
@@ -2,6 +2,14 @@
 	try {
 		Array.from({ length: -Infinity });
 
+		if (Array.from(new self.Set(['a']))[0] !== 'a') {
+			return false;
+		}
+
+		if (Array.from(new self.Map([['a', 'one']]))[0][0] !== 'a') {
+			return false;
+		}
+
 		return true;
 	} catch (e) {
 		return false;

--- a/polyfills/Map/config.toml
+++ b/polyfills/Map/config.toml
@@ -29,8 +29,9 @@ notes = [
 [browsers]
 ie = "*"
 safari = "<9"
+edge = "<13"
 firefox = "<36"
-chrome = "<45"
+chrome = "<49"
 android = "<5.1"
 firefox_mob = "<29"
 ie_mob = "*"

--- a/polyfills/Set/config.toml
+++ b/polyfills/Set/config.toml
@@ -26,10 +26,10 @@ notes = [
 
 [browsers]
 ie = "*"
-edge = "<12"
+edge = "<13"
 safari = "<9"
 firefox = "<36"
-chrome = "<45"
+chrome = "<49"
 android = "<5.1"
 firefox_mob = "<29"
 ie_mob = "*"

--- a/polyfills/Symbol/iterator/tests.js
+++ b/polyfills/Symbol/iterator/tests.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha, browser */
-/* global proclaim, Symbol */
+/* global proclaim, Symbol, Set, Map */
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
@@ -63,3 +63,43 @@ hasNodeListGlobal('can attach to a NodeList correctly', function() {
 
 	proclaim.equal(dom[0].innerHTML, 'Test');
 });
+
+if ('from' in Array) {
+	it('does not break "Array.from" with an Array', function () {
+		var a = [];
+		a.push('a');
+		proclaim.equal(Array.from(a)[0], 'a');
+	});
+
+	if ('Set' in self) {
+		it('does not break "Array.from" with a Set', function () {
+			var s = new Set();
+			s.add('a');
+			proclaim.equal(Array.from(s)[0], 'a')
+		});
+	}
+
+	if ('Map' in self) {
+		it('does not break "Array.from" with a Map', function () {
+			var m = new Map();
+			m.set('a', '1');
+			proclaim.equal(Array.from(m)[0][0], 'a');
+		});
+	}
+
+	it('does not break "Array.from" with function arguments', function () {
+		function f() {
+			return Array.from(arguments);
+		}
+		proclaim.equal(Array.from(f('a', 'b'))[0], 'a');
+	});
+
+	it('does not break "Array.from" with a NodeList', function () {
+		var imgA = document.createElement('IMG');
+		var imgB = document.createElement('IMG');
+		document.body.appendChild(imgA);
+		document.body.appendChild(imgB);
+		var images = document.getElementsByTagName('img');
+		proclaim.equal(Array.from(images)[0], imgA);
+	});
+}

--- a/polyfills/URL/config.toml
+++ b/polyfills/URL/config.toml
@@ -11,7 +11,8 @@ dependencies = [
   "Object.defineProperties",
   "Array.prototype.forEach",
   "Array.isArray",
-  "Array.from"
+  "Array.from",
+  "Symbol.iterator"
 ]
 notes = [ "Polyfill requires Object getters so fails in IE <= 8" ]
 license = "CC0-1.0"

--- a/polyfills/URL/tests.js
+++ b/polyfills/URL/tests.js
@@ -296,11 +296,23 @@ it('URLSearchParams serialization', function() {
 	proclaim.equal(p.get('a  b'), 'a  b');
 });
 
-it('URLSearchParams iterable methods', function () {
+it('URLSearchParams iterable methods - entries', function () {
 	var params = new URLSearchParams('a=1&b=2');
 	proclaim.deepEqual(Array.from(params.entries()), [['a', '1'], ['b', '2']]);
+});
+
+it('URLSearchParams iterable methods - keys', function () {
+	var params = new URLSearchParams('a=1&b=2');
 	proclaim.deepEqual(Array.from(params.keys()), ['a', 'b']);
+});
+
+it('URLSearchParams iterable methods - values', function () {
+	var params = new URLSearchParams('a=1&b=2');
 	proclaim.deepEqual(Array.from(params.values()), ['1', '2']);
+});
+
+it('URLSearchParams iterable methods - Symbol.iterator', function () {
+	var params = new URLSearchParams('a=1&b=2');
 
 	if ('Symbol' in self && 'iterator' in self.Symbol) {
 		proclaim.deepEqual(Array.from(params[self.Symbol.iterator]()), [['a', '1'], ['b', '2']]);


### PR DESCRIPTION
Two issues found :

- `Array.from` is supported natively in some browsers without the ability to process iterables
- `Set` and `Map` polyfills were not loaded in browsers that needed `Set|Map.prototype[Symbol.iterable]`


Full test run (including polyfill combinations) : https://github.com/romainmenke/polyfill-library/actions/runs/838607240

fixes : #1053