### PR TITLE
fix polyfill combination with time zone data

### DIFF
--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -85,7 +85,17 @@ app.get(
 
 		if (includePolyfills === "yes") {
 			const polyfillsWithTests = await testablePolyfills(isIE8);
-			const features = polyfillsWithTests.map(polyfill => polyfill.feature);
+			let features = polyfillsWithTests.map(polyfill => polyfill.feature);
+
+			// Exclude polyfills which must not be loaded together
+			if (polyfillCombinations) {
+				// "timeZone.golden" and "timeZone.all" overlap.
+				// Including both is a user error.
+				features = features.filter((x) => {
+					return x !== 'Intl.DateTimeFormat.~timeZone.golden';
+				})
+			}
+
 			const parameters = {
 				features: createPolyfillLibraryConfigFor(
 					(feature && !polyfillCombinations) ? feature : features.join(","),


### PR DESCRIPTION
see : https://github.com/Financial-Times/polyfill-library/runs/2815491287?check_suite_focus=true

In this test we load all polyfills.
This means both "all" and "golden" are loaded and polyfilled, but they overlap.

Currently there is no mechanism to ensure that two polyfills are not loaded together.
I think that in itself is fine, including both is essentially a user error.

I added a filter in `server.js` to skip "golden" polyfill.
Tests for "golden" must work with the data from "all"
