### PR TITLE
fix `URL` + `fetch` interop

### DIFF
--- a/polyfills/URL/config.toml
+++ b/polyfills/URL/config.toml
@@ -20,7 +20,7 @@ repo = "https://github.com/inexorabletash/polyfill"
 docs = "https://developer.mozilla.org/en-US/docs/Web/API/URL"
 
 [browsers]
-chrome = "<60"
+chrome = "<61"
 firefox = "<54"
 edge = "<18.17134"
 edge_mob = "<17"

--- a/polyfills/URL/polyfill.js
+++ b/polyfills/URL/polyfill.js
@@ -17,7 +17,7 @@
 		return false;
 	}
 
-	(function() {
+	;(function() { // eslint-disable-line no-extra-semi
 
 		// Browsers may have:
 		// * No global URL object
@@ -489,7 +489,7 @@
 
 		global.URL = URL;
 		global.URLSearchParams = URLSearchParams;
-	}());
+	})();
 
 	// Patch native URLSearchParams constructor to handle sequences/records
 	// if necessary.
@@ -518,6 +518,6 @@
 				return new orig(init);
 			}
 		};
-	}());
+	})();
 
 }(self));

--- a/polyfills/URL/tests.js
+++ b/polyfills/URL/tests.js
@@ -340,6 +340,14 @@ it('URLSearchParams doesnt stringify with "Object"', function() {
 	proclaim.equal(p.toString(), "key=730d67");
 });
 
+it('URLSearchParams constructed form a Record has working "get"', function() {
+	var p1 = new URLSearchParams({ "key": "alpha" }); // eslint-disable-line
+	proclaim.equal(p1.get('key'), "alpha");
+
+	var p2 = new URLSearchParams({ key: "beta" });
+	proclaim.equal(p2.get('key'), "beta");
+});
+
 describe('WPT tests', function () {
 	it('appends same name correctly', function() {
 		var params = new URLSearchParams();

--- a/polyfills/fetch/config.toml
+++ b/polyfills/fetch/config.toml
@@ -3,7 +3,8 @@ dependencies = [
 	"Object.getOwnPropertyNames",
 	"Promise",
 	"XMLHttpRequest",
-	"Symbol.iterator"
+	"Symbol.iterator",
+	"URL"
 ]
 license = "MIT"
 spec = "https://fetch.spec.whatwg.org/"

--- a/polyfills/fetch/tests.js
+++ b/polyfills/fetch/tests.js
@@ -6,3 +6,29 @@
 it('exists', function () {
 	proclaim.ok('fetch' in self);
 });
+
+if ('URLSearchParams' in self) {
+	it('works with URLSearchParams as Request body', function (done) {
+		// https://github.com/Financial-Times/polyfill-library/issues/870
+		var request = new Request('#', { body: new URLSearchParams({ foo: 'baz' }), method: 'POST' });
+		if (!('text' in request)) {
+			proclaim.fail('expected "text" function in Request');
+			return;
+		}
+
+		var text = request.text();
+		if (!('then' in text)) {
+			proclaim.fail('expected "then" function in text body');
+			return;
+		}
+
+		text.then(function (x) {
+			try {
+				proclaim.equal(x, 'foo=baz');
+				done();
+			} catch (e) {
+				done(e);
+			}
+		});
+	});
+}


### PR DESCRIPTION
should fix : https://github.com/Financial-Times/polyfill-library/issues/870

There is also a minification issue with an `iife` in the URL polyfill.
I added a few more semicolons around the `iife`'s here.
I can only reproduce it against polyfill.io so I am not sure it is fully fixed.
