### PR TITLE
add timeZone data in all browsers that need Intl.DateTimeFormat

### DIFF
--- a/polyfills/Intl/DateTimeFormat/config.toml
+++ b/polyfills/Intl/DateTimeFormat/config.toml
@@ -28,6 +28,7 @@ notes = [
 	"Locales must be specified separately by prefixing the locale name with `Intl.DateTimeFormat.~locale`, eg `Intl.DateTimeFormat.~locale.en-GB`."
 ]
 
+# Browser compatibility list for Int.DateTimeFormat.~timeZone.all and Int.DateTimeFormat.~timeZone.golden must match this one, update both if a change is needed here.
 [browsers]
 android = "*"
 ie = "9 - *"

--- a/polyfills/Intl/DateTimeFormat/~timeZone/all/config.toml
+++ b/polyfills/Intl/DateTimeFormat/~timeZone/all/config.toml
@@ -19,16 +19,18 @@ notes = [
 
 #### Browser compatibility
 [browsers]
-android = "<4.4"
+android = "*"
 ie = "9 - *"
 ie_mob = "9 - *"
-firefox = "<52"
-opera = "<15"
-chrome = "<24"
-safari = "<10"
-ios_saf = "<10"
-firefox_mob = "<52"
-samsung_mob = "<1.5"
+edge = "<79"
+edge_mob = "<79"
+firefox = "*"
+opera = "*"
+chrome = "<76"
+safari = "*"
+ios_saf = "*"
+firefox_mob = "*"
+samsung_mob = "*"
 
 [install]
 module = "@formatjs/intl-datetimeformat"

--- a/polyfills/Intl/DateTimeFormat/~timeZone/all/config.toml
+++ b/polyfills/Intl/DateTimeFormat/~timeZone/all/config.toml
@@ -18,6 +18,7 @@ notes = [
 ]
 
 #### Browser compatibility
+# Browser compatibility list sourced from Intl.DateTimeFormat.
 [browsers]
 android = "*"
 ie = "9 - *"

--- a/polyfills/Intl/DateTimeFormat/~timeZone/golden/config.toml
+++ b/polyfills/Intl/DateTimeFormat/~timeZone/golden/config.toml
@@ -19,16 +19,18 @@ notes = [
 
 #### Browser compatibility
 [browsers]
-android = "<4.4"
+android = "*"
 ie = "9 - *"
 ie_mob = "9 - *"
-firefox = "<52"
-opera = "<15"
-chrome = "<24"
-safari = "<10"
-ios_saf = "<10"
-firefox_mob = "<52"
-samsung_mob = "<1.5"
+edge = "<79"
+edge_mob = "<79"
+firefox = "*"
+opera = "*"
+chrome = "<76"
+safari = "*"
+ios_saf = "*"
+firefox_mob = "*"
+samsung_mob = "*"
 
 [install]
 module = "@formatjs/intl-datetimeformat"

--- a/polyfills/Intl/DateTimeFormat/~timeZone/golden/config.toml
+++ b/polyfills/Intl/DateTimeFormat/~timeZone/golden/config.toml
@@ -18,6 +18,7 @@ notes = [
 ]
 
 #### Browser compatibility
+# Browser compatibility list sourced from Intl.DateTimeFormat.
 [browsers]
 android = "*"
 ie = "9 - *"


### PR DESCRIPTION
fixes : #1075

Exact copy of `Intl.DateTimeFormat` browser config.