### PR TITLE
check for AbortSignal feature in fetch detect.js

### DIFF
--- a/polyfills/fetch/config.toml
+++ b/polyfills/fetch/config.toml
@@ -1,5 +1,6 @@
 dependencies = [
 	"Array.prototype.forEach",
+	"Array.isArray",
 	"Object.getOwnPropertyNames",
 	"Promise",
 	"XMLHttpRequest",

--- a/polyfills/fetch/detect.js
+++ b/polyfills/fetch/detect.js
@@ -1,1 +1,7 @@
-'fetch' in self
+'fetch' in self && 'Request' in self && (function () {
+	try {
+		return ( 'signal' in ( new Request('') ) );
+	} catch (e) {
+		return false;
+	}
+}())

--- a/polyfills/fetch/tests.js
+++ b/polyfills/fetch/tests.js
@@ -35,8 +35,10 @@ if ('URLSearchParams' in self) {
 
 if ('AbortController' in self) {
 	it('sets signal on Request instantiation', function () {
-		var req = new Request('#');
+		var ctrl = new AbortController();
+		ctrl.abort();
+		var req = new Request('#', { signal: ctrl.signal });
 		proclaim.ok(req.signal);
-		proclaim.equal(req.signal.aborted, false);
+		proclaim.ok(req.signal.aborted);
 	});
 }

--- a/polyfills/fetch/tests.js
+++ b/polyfills/fetch/tests.js
@@ -32,3 +32,11 @@ if ('URLSearchParams' in self) {
 		});
 	});
 }
+
+if ('AbortController' in self) {
+	it('sets signal on Request instantiation', function () {
+		var req = new Request('#');
+		proclaim.ok(req.signal);
+		proclaim.equal(req.signal.aborted, false);
+	});
+}


### PR DESCRIPTION
The `fetch` polyfill `detect.js` only checked against basic support.

This change will make more feature available even when using the `gated` flag.