### PR TITLE
update Intl.DateTimeFormat config and detect

### DIFF
--- a/polyfills/Intl/DateTimeFormat/config.toml
+++ b/polyfills/Intl/DateTimeFormat/config.toml
@@ -30,18 +30,18 @@ notes = [
 
 # Browser compatibility list for Int.DateTimeFormat.~timeZone.all and Int.DateTimeFormat.~timeZone.golden must match this one, update both if a change is needed here.
 [browsers]
-android = "*"
+android = "<76"
 ie = "9 - *"
 ie_mob = "9 - *"
 edge = "<79"
 edge_mob = "<79"
 firefox = "<91"
-opera = "*"
+opera = "<63"
 chrome = "<76"
-safari = "*"
-ios_saf = "*"
-firefox_mob = "*"
-samsung_mob = "*"
+safari = "<14.1"
+ios_saf = "<14.1"
+firefox_mob = "<91"
+samsung_mob = "<12"
 
 [install]
 module = "@formatjs/intl-datetimeformat"

--- a/polyfills/Intl/DateTimeFormat/detect.js
+++ b/polyfills/Intl/DateTimeFormat/detect.js
@@ -1,5 +1,6 @@
 'Intl' in self &&
-'DateTimeFormat' in self.Intl &&
-'formatToParts' in self.Intl.DateTimeFormat.prototype &&
-new self.Intl.DateTimeFormat('en', {hourCycle: 'h11', hour: 'numeric'})
-	.formatToParts(0)[2].type === 'dayPeriod'
+	'DateTimeFormat' in self.Intl &&
+	'formatToParts' in self.Intl.DateTimeFormat.prototype &&
+	new self.Intl.DateTimeFormat('en', {hourCycle: 'h11', hour: 'numeric'}).formatToParts(0)[2].type === 'dayPeriod' &&
+	'formatRangeToParts' in self.Intl.DateTimeFormat.prototype &&
+	new self.Intl.DateTimeFormat('en', {hourCycle: 'h11', hour: 'numeric'}).formatRangeToParts(0, 1)[2].type === 'dayPeriod'

--- a/polyfills/Intl/DateTimeFormat/update.task.js
+++ b/polyfills/Intl/DateTimeFormat/update.task.js
@@ -80,7 +80,7 @@ configSource.test = { ci: false };
 function intlLocaleDetectFor(locale) {
 	return `'Intl' in self &&
 	'DateTimeFormat' in self.Intl &&
-	'formatToParts' in self.Intl.DateTimeFormat &&
+	'formatRangeToParts' in self.Intl.DateTimeFormat &&
 	self.Intl.DateTimeFormat.supportedLocalesOf('${locale}').length`;
 }
 


### PR DESCRIPTION
see : https://github.com/Financial-Times/polyfill-library/commit/af38c6a9a9fda2b45b4410117399f3ad4fabe4d9

tests : https://mrhenry.github.io/web-tests/#1bc7e152-dce1-46cb-a6df-08e5f181d84d
(tests assume that `polyfill.io` has the latest version of `polyfill-library`, so there are false negatives there at the moment)

This should also resolve issues with the polyfill not being applied with the gated flag.