### PR TITLE
Update config.toml for DOMTokenList.prototype.@@iterator

### DIFF
--- a/polyfills/DOMTokenList/prototype/@@iterator/config.toml
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.toml
@@ -5,7 +5,7 @@ spec = "https://dom.spec.whatwg.org/#domtokenlist"
 [browsers]
 edge = "<16"
 edge_mob = "<16"
-ie = "9-12"
+ie = "9 - 12"
 ie_mob = "9 - 12"
 safari = "<10.1"
 chrome = "<50"


### PR DESCRIPTION
Apparently `9-12` is an invalid semver range.
`semver.satisfies`  just returns `false` in case of errors, so this went undetected.

https://github.com/Financial-Times/polyfill-useragent-normaliser/blob/master/compilers/node.js#L128
https://github.com/npm/node-semver/blob/main/functions/satisfies.js#L6