### PR TITLE
fix DOMTokenList.prototype.@@iterator

### DIFF
--- a/polyfills/DOMTokenList/prototype/@@iterator/config.toml
+++ b/polyfills/DOMTokenList/prototype/@@iterator/config.toml
@@ -1,4 +1,10 @@
-dependencies = [ "_ArrayIterator", "Symbol.iterator", "DOMTokenList" ]
+dependencies = [
+	"_ArrayIterator",
+	"Symbol.iterator",
+	"DOMTokenList",
+	"Element.prototype.classList"
+]
+
 license = "MIT"
 spec = "https://dom.spec.whatwg.org/#domtokenlist"
 


### PR DESCRIPTION
see : https://github.com/Financial-Times/polyfill-library/runs/4178779412?check_suite_focus=true

```
 - ie/9.0:
    -> DOMTokenList.prototype.@@iterator finally returns a done object
       http://bs-local.com:9876/test?includePolyfills=yes&always=no&feature=DOMTokenList.prototype.@@iterator
       Unable to get value of the property '__symbol:iterator0.336679911648032571': object is null or undefined
```

It seems this one was broken but never tested because : https://github.com/Financial-Times/polyfill-library/commit/66bf782835b1983933cffd3ebb454ca5859921a4

(config for `forEach` : https://github.com/Financial-Times/polyfill-library/blob/109533b9f9965483c4be848fb48943854d0e4526/polyfills/DOMTokenList/prototype/forEach/config.toml)