### PR TITLE
allow workflow_dispatch in test-polyfills.yml

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   repository_dispatch:
     types: [ok-to-test-command]
+  workflow_dispatch:
 
 jobs:
   # Branch-based pull request


### PR DESCRIPTION
Currently running CI from a fork is no longer possible on the forked repo.
Allowing `workflow_dispatch` makes it possible to run CI on the fork.

It does require bringing your own credentials for browserstack.
But for regular contributors it is very handy to run all tests before opening a pull request.