### PR TITLE
Improves iterator tests for `Promise.any`, `Promise.allSettled`, and `AggregateError` polyfills

### DIFF
--- a/polyfills/AggregateError/tests.js
+++ b/polyfills/AggregateError/tests.js
@@ -1,6 +1,22 @@
 
 /* globals proclaim, AggregateError */
 
+function makeArrayIterator (array) {
+	var i = 0;
+	var iterator = {};
+	// polyfill for `Symbol.iterator` has been provided as part of `IterableToList`
+	iterator[self.Symbol.iterator] = function () {
+		return {
+			next: function() {
+				return i >= array.length
+					? { done: true }
+					: { value: array[i++] };
+			}
+		};
+	};
+	return iterator;
+}
+
 it('is a function', function () {
 	proclaim.isFunction(AggregateError);
 });
@@ -29,15 +45,14 @@ describe('AggregateError', function () {
 		proclaim.deepStrictEqual(aggregateError.errors, errors);
 	});
 
-	if ('Symbol' in self && 'iterator' in self.Symbol && !!Array.prototype[self.Symbol.iterator]) {
-		it("constructs an AggregateError when passed an iterator", function () {
-			var errors = [new Error('x'), new Error('y')];
-			var aggregateError = new AggregateError(errors[self.Symbol.iterator]());
-			proclaim.equal(aggregateError.message, '');
-			proclaim.notEqual(aggregateError.errors, errors);
-			proclaim.deepStrictEqual(aggregateError.errors, errors);
-		});
-	}
+	it("constructs an AggregateError when passed an iterator", function () {
+		var errors = [new Error('x'), new Error('y')];
+		var iterator = makeArrayIterator(errors);
+		var aggregateError = new AggregateError(iterator);
+		proclaim.equal(aggregateError.message, '');
+		proclaim.notEqual(aggregateError.errors, errors);
+		proclaim.deepStrictEqual(aggregateError.errors, errors);
+	});
 
 	it("throws an error for input that is not iterable", function () {
 		proclaim['throws'](function () {

--- a/polyfills/Promise/any/tests.js
+++ b/polyfills/Promise/any/tests.js
@@ -1,6 +1,22 @@
 
 /* globals proclaim, Promise */
 
+function makeArrayIterator (array) {
+	var i = 0;
+	var iterator = {};
+	// polyfill for `Symbol.iterator` has been provided as part of `IterableToList`
+	iterator[self.Symbol.iterator] = function () {
+		return {
+			next: function() {
+				return i >= array.length
+					? { done: true }
+					: { value: array[i++] };
+			}
+		};
+	};
+	return iterator;
+}
+
 it('is a function', function () {
 	proclaim.isFunction(Promise.any);
 });
@@ -40,33 +56,35 @@ describe('any', function () {
 		});
 	});
 
-	if ('Symbol' in self && 'iterator' in self.Symbol && !!Array.prototype[self.Symbol.iterator]) {
-		it("resolves to the first fulfilled promise when passed an iterator", function () {
-			var promises = [Promise.reject(1), Promise.resolve(2), 3];
-			return Promise.any(promises[self.Symbol.iterator]()).then(function (result) {
-				proclaim.strictEqual(result, 2);
-			});
+	it("resolves to the first fulfilled promise when passed an iterator", function () {
+		var promises = [Promise.reject(1), Promise.resolve(2), 3];
+		var iterator = makeArrayIterator(promises);
+		return Promise.any(iterator).then(function (result) {
+			proclaim.strictEqual(result, 2);
 		});
+	});
 
-		it("rejects with an AggregateError when passed an iterator containing rejected promises", function () {
-			var promises = [Promise.reject(1)];
-			return Promise.any(promises[self.Symbol.iterator]())['catch'](function (err) {
-				return err;
-			}).then(function (err) {
-				proclaim.equal(err.name, 'AggregateError');
-				proclaim.deepStrictEqual(err.errors, [1]);
-			});
+	it("rejects with an AggregateError when passed an iterator containing rejected promises", function () {
+		var promises = [Promise.reject(1)];
+		var iterator = makeArrayIterator(promises);
+		return Promise.any(iterator)['catch'](function (err) {
+			return err;
+		}).then(function (err) {
+			proclaim.equal(err.name, 'AggregateError');
+			proclaim.deepStrictEqual(err.errors, [1]);
 		});
+	});
 
-		it("rejects with an AggregateError when passed an empty iterable", function () {
-			return Promise.any([][self.Symbol.iterator]())['catch'](function (err) {
-				return err;
-			}).then(function (err) {
-				proclaim.equal(err.name, 'AggregateError');
-				proclaim.deepStrictEqual(err.errors, []);
-			});
+	it("rejects with an AggregateError when passed an empty iterable", function () {
+		var promises = [];
+		var iterator = makeArrayIterator(promises);
+		return Promise.any(iterator)['catch'](function (err) {
+			return err;
+		}).then(function (err) {
+			proclaim.equal(err.name, 'AggregateError');
+			proclaim.deepStrictEqual(err.errors, []);
 		});
-	}
+	});
 
 	it("rejects with a TypeError for input that is not iterable", function () {
 		return Promise.any(0)['catch'](function (err) {


### PR DESCRIPTION
This PR improves tests for `Promise.any`, `Promise.allSettled`, and `AggregateError` polyfills so that they run in all browsers.