### PR TITLE
Bump minimum node version to 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -390,24 +390,12 @@
       }
     },
     "@formatjs/intl-localematcher": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.13.tgz",
-      "integrity": "sha512-lx0/ILBbs9hVmNR0hqyf1Ym8412oQi7UO471YMGvYAqTQRnFcrLQW1gh7W5CZOlzsbN04RMvnJfmlp+fu2GKZA==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.1",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@formatjs/ecma402-abstract": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.1.tgz",
-          "integrity": "sha512-XAJ1ygWKgGEaFuNg3Cf+maJNYEJjl5LjSVZ1iAnSaOKDg/VXa+dDPWhWQP6jimvWv6h9NyDj6Zgh+2qFBeVABw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "@formatjs/intl-numberformat": {
@@ -865,9 +853,9 @@
       }
     },
     "apicache": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.6.2.tgz",
-      "integrity": "sha512-3z5e+1E2qwZoqzFVgdx5l9nGhSG0kHv3v2G170vnJSz5uj4mCLVZfRw0o37aWwV8pTPXSkB8OBZz3TIur4H26g==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.6.3.tgz",
+      "integrity": "sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w==",
       "dev": true
     },
     "append-transform": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "files": [
     "/CHANGELOG.md",
@@ -71,7 +71,7 @@
     "@formatjs/intl-getcanonicallocales": "1.6.0",
     "@formatjs/intl-listformat": "6.1.0",
     "@formatjs/intl-locale": "2.4.26",
-    "@formatjs/intl-localematcher": "^0.2.13",
+    "@formatjs/intl-localematcher": "^0.2.21",
     "@formatjs/intl-numberformat": "7.1.0",
     "@formatjs/intl-pluralrules": "4.0.20",
     "@formatjs/intl-relativetimeformat": "9.1.0",
@@ -79,7 +79,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@webcomponents/template": "^1.4.0",
     "abort-controller": "^3.0.0",
-    "apicache": "^1.5.3",
+    "apicache": "^1.6.3",
     "array.prototype.flatmap": "^1.2.1",
     "audio-context-polyfill": "^1.0.0",
     "auto-changelog": "^2.2.1",


### PR DESCRIPTION
This PR bumps the minimum Node.js version to 12. It also fixes support for Node.js 16 by upgrading a couple dependencies (e.g. https://github.com/formatjs/formatjs/issues/3058).