### PR TITLE
Remove IE 8 workarounds

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -55,7 +55,7 @@ For example:
 ```toml
 dependencies = [
 	"Element",
-	"Object.defineProperty"
+	"Object.defineProperties"
 ]
 ```
 
@@ -92,11 +92,11 @@ If all versions of a browser require the polyfill you can use the wildcard aster
 android = "*"
 ```
 
-For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 8 and below you can use "<9":
+For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 10 and below you can use "<11":
 
 ```toml
 [browsers]
-ie = "<9"
+ie = "<11"
 ```
 
 #### Additional information

--- a/polyfills/Blob/polyfill.js
+++ b/polyfills/Blob/polyfill.js
@@ -201,11 +201,7 @@
 		var blobParts = arguments[0];
 		var options = arguments[1];
 
-		try {
-			var isInstanceOfBlob = this instanceof Blob;
-		} catch (e) {
-			// Polyfill.io - IE 8 throws an error when using instanceof
-		}
+		var isInstanceOfBlob = this instanceof Blob;
 		if (isInstanceOfBlob === false) {
 			throw new TypeError("Failed to construct 'Blob': Please use the 'new' operator, this DOM object constructor cannot be called as a function.");
 		}

--- a/polyfills/CustomEvent/polyfill.js
+++ b/polyfills/CustomEvent/polyfill.js
@@ -6,21 +6,14 @@ self.CustomEvent = function CustomEvent(type, eventInitDict) {
 	var event;
 	eventInitDict = eventInitDict || {bubbles: false, cancelable: false, detail: null};
 
-	if ('createEvent' in document) {
-		try {
-			event = document.createEvent('CustomEvent');
-			event.initCustomEvent(type, eventInitDict.bubbles, eventInitDict.cancelable, eventInitDict.detail);
-		} catch (error) {
-			// for browsers which don't support CustomEvent at all, we use a regular event instead
-			event = document.createEvent('Event');
-			event.initEvent(type, eventInitDict.bubbles, eventInitDict.cancelable);
-			event.detail = eventInitDict.detail;
-		}
-	} else {
-
-		// IE8
-		event = new Event(type, eventInitDict);
-		event.detail = eventInitDict && eventInitDict.detail || null;
+	try {
+		event = document.createEvent('CustomEvent');
+		event.initCustomEvent(type, eventInitDict.bubbles, eventInitDict.cancelable, eventInitDict.detail);
+	} catch (error) {
+		// for browsers which don't support CustomEvent at all, we use a regular event instead
+		event = document.createEvent('Event');
+		event.initEvent(type, eventInitDict.bubbles, eventInitDict.cancelable);
+		event.detail = eventInitDict.detail;
 	}
 	return event;
 };

--- a/polyfills/Element/polyfill.js
+++ b/polyfills/Element/polyfill.js
@@ -3,11 +3,6 @@
 	if ('Element' in self && 'HTMLElement' in self) {
 		return;
 	}
-	// IE8
-	if (window.Element && !window.HTMLElement) {
-		window.HTMLElement = window.Element;
-		return;
-	}
 
 	// create Element constructor
 	window.Element = window.HTMLElement = new Function('return function Element() {}')();

--- a/polyfills/Element/prototype/classList/polyfill.js
+++ b/polyfills/Element/prototype/classList/polyfill.js
@@ -7,23 +7,12 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 (function (global) {
-	var dpSupport = true;
 	var defineGetter = function (object, name, fn, configurable) {
-		if (Object.defineProperty)
-			Object.defineProperty(object, name, {
-				configurable: false === dpSupport ? true : !!configurable,
-				get: fn
-			});
-
-		else object.__defineGetter__(name, fn);
+		Object.defineProperty(object, name, {
+			configurable: !!configurable,
+			get: fn
+		});
 	};
-	/** Ensure the browser allows Object.defineProperty to be used on native JavaScript objects. */
-	try {
-		defineGetter({}, "support");
-	}
-	catch (e) {
-		dpSupport = false;
-	}
 	/** Polyfills a property with a DOMTokenList */
 	var addProp = function (o, name, attr) {
 
@@ -37,32 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 			if(THIS[gibberishProperty]) return tokenList;
 			THIS[gibberishProperty] = true;
 
-			/**
-			 * IE8 can't define properties on native JavaScript objects, so we'll use a dumb hack instead.
-			 *
-			 * What this is doing is creating a dummy element ("reflection") inside a detached phantom node ("mirror")
-			 * that serves as the target of Object.defineProperty instead. While we could simply use the subject HTML
-			 * element instead, this would conflict with element types which use indexed properties (such as forms and
-			 * select lists).
-			 */
-			if (false === dpSupport) {
-
-				var visage;
-				var mirror = addProp.mirror || document.createElement("div");
-				var reflections = mirror.childNodes;
-				var l = reflections.length;
-
-				for (var i = 0; i < l; ++i)
-					if (reflections[i]._R === THIS) {
-						visage = reflections[i];
-						break;
-					}
-
-				/** Couldn't find an element's reflection inside the mirror. Materialise one. */
-				visage || (visage = mirror.appendChild(document.createElement("div")));
-
-				tokenList = DOMTokenList.call(visage, THIS, attr);
-			} else tokenList = new _DOMTokenList(THIS, attr);
+			tokenList = new _DOMTokenList(THIS, attr);
 
 			defineGetter(THIS, name, function () {
 				return tokenList;

--- a/polyfills/Element/prototype/cloneNode/tests.js
+++ b/polyfills/Element/prototype/cloneNode/tests.js
@@ -49,8 +49,7 @@ it('should retain checked state of checkbox elements', function() {
 	proclaim.equal(clone.checked, true);
 });
 
-/* TEST SKIPPED: this doesn't work in IE < 9, which results in <:nav></:nav>.  Support for this could probably be added to the polyfill */
-it.skip('can clone HTML5 elements', function() {
+it('can clone HTML5 elements', function() {
 	var clone = document.createElement('nav').cloneNode();
 	proclaim.equal(htmlify(clone), '<nav></nav>');
 });

--- a/polyfills/Element/prototype/toggleAttribute/tests.js
+++ b/polyfills/Element/prototype/toggleAttribute/tests.js
@@ -12,8 +12,7 @@ describe('Element.prototype.toggleAttribute', function() {
 		document.body.removeChild(el);
 	});
 
-	// TODO: IE8 does not throw any error. Should throw INVALID_CHARACTER_ERR. Should we support this?
-	it.skip("should throw an error if the attribute name is not valid", function () {
+	it("should throw an error if the attribute name is not valid", function () {
 		proclaim["throws"](function () {
 			el.toggleAttribute('$');
 		});

--- a/polyfills/Event/polyfill.js
+++ b/polyfills/Event/polyfill.js
@@ -1,22 +1,4 @@
 (function () {
-	var unlistenableWindowEvents = {
-		click: 1,
-		dblclick: 1,
-		keyup: 1,
-		keypress: 1,
-		keydown: 1,
-		mousedown: 1,
-		mouseup: 1,
-		mousemove: 1,
-		mouseover: 1,
-		mouseenter: 1,
-		mouseleave: 1,
-		mouseout: 1,
-		storage: 1,
-		storagecommit: 1,
-		textinput: 1
-	};
-
 	// This polyfill depends on availability of `document` so will not run in a worker
 	// However, we asssume there are no browsers with worker support that lack proper
 	// support for `Event` within the worker
@@ -68,10 +50,6 @@
 			element = this,
 			type = arguments[0],
 			listener = arguments[1];
-
-			if (element === window && type in unlistenableWindowEvents) {
-				throw new Error('In IE8 the event: ' + type + ' is not available on the window object. Please see https://github.com/Financial-Times/polyfill-service/issues/317 for more information.');
-			}
 
 			if (!element._events) {
 				element._events = {};

--- a/polyfills/HTMLInputElement/prototype/valueAsDate/config.toml
+++ b/polyfills/HTMLInputElement/prototype/valueAsDate/config.toml
@@ -19,7 +19,6 @@ license = "MIT"
 #### Notes
 notes = [
 	"Safari older than 10.1 does not allow re-defining 'HTMLInputElement.prototype.valueAsDate'.",
-	"IE8 doesn't have 'setter' support, so we can't serve this polyfill",
 	"Browsers that do not support date|month|week|time also won't have type property support. This implies we have to look at the attribute of the element. Setting the property without updating the attribute will have unexpected behaviour."
 ]
 

--- a/polyfills/HTMLPictureElement/detect.js
+++ b/polyfills/HTMLPictureElement/detect.js
@@ -1,2 +1,1 @@
-/* Picturefill does not set the HTMLPictureElement global, and the srcset property of <source> does not appear to be accessible to JS in IE8, so in IE8 the only way to detect that the polyfill has applied is to use a non-standard global exposed by the polyfill */
-'HTMLPictureElement' in self || 'picturefill' in self
+'HTMLSourceElement' in self && 'srcset' in self.HTMLSourceElement.prototype

--- a/polyfills/HTMLSelectElement/prototype/selectedOptions/config.toml
+++ b/polyfills/HTMLSelectElement/prototype/selectedOptions/config.toml
@@ -8,7 +8,6 @@ dependencies = [
 ]
 
 notes = [
-	"Polyfill requires Object getters so fails in IE < 8",
 	"Polyfill does not return a live HTMLCollection, only a static NodeList that has the same methods as an HTMLCollection",
 ]
 

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -19,18 +19,14 @@ it('is not enumerable', function () {
 
 var arePropertyDescriptorsSupported = function() {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', {
-			enumerable: false,
-			value: obj
-		});
-		for (var _ in obj) {
-			return false;
-		}
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
+	Object.defineProperty(obj, 'x', {
+		enumerable: false,
+		value: obj
+	});
+	for (var _ in obj) {
 		return false;
 	}
+	return obj.x === obj;
 };
 
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();

--- a/polyfills/MediaQueryList/prototype/addEventListener/polyfill.js
+++ b/polyfills/MediaQueryList/prototype/addEventListener/polyfill.js
@@ -1,23 +1,6 @@
 (function(global) {
 	"use strict";
 
-	var _supportsSetters = (function () {
-		// supports setters (not IE8)
-		try {
-			var a = {};
-			global.Object.defineProperty(a, 't', {
-				configurable: true,
-				enumerable: false,
-				get: function () { return this._v; },
-				set: function (v) { this._v = v + v; }
-			});
-			a.t = 1;
-			return (a.t === 2);
-		} catch (e) {
-			return false;
-		}
-	}());
-
 	function addEventListener(type, listener) {
 		if (type === 'change') {
 			this.addListener(listener);
@@ -89,11 +72,7 @@
 
 		global.MediaQueryList.prototype.removeEventListener = removeEventListener;
 
-		// Best effort.
-		// Some browsers don't support setters.
-		if (_supportsSetters) {
-			global.Object.defineProperty(global.MediaQueryList.prototype, "onchange", onchangeDescriptor);
-		}
+		global.Object.defineProperty(global.MediaQueryList.prototype, "onchange", onchangeDescriptor);
 	} else { /* Safari does not expose "MediaQueryList" globally */
 		var _matchMedia = self.matchMedia;
 
@@ -125,11 +104,7 @@
 
 			_mql.removeEventListener = removeEventListener;
 
-			// Best effort.
-			// Some browsers don't support setters.
-			if (_supportsSetters) {
-				global.Object.defineProperty(_mql, "onchange", onchangeDescriptor);
-			}
+			global.Object.defineProperty(_mql, "onchange", onchangeDescriptor);
 
 			return _mql;
 		}

--- a/polyfills/MediaQueryList/prototype/addEventListener/tests.js
+++ b/polyfills/MediaQueryList/prototype/addEventListener/tests.js
@@ -271,100 +271,78 @@ if (typeof (self.matchMedia('(min-width: 1px)').listeners) === 'undefined') {
 			}, done);
 		});
 
-		if ((function () {
-			// supports setters (not IE8)
-			try {
-				var a = {};
-				Object.defineProperty(a, 't', {
-					configurable: true,
-					enumerable: false,
-					get: function () {
-						return this._v;
-					},
-					set: function (v) {
-						this._v = v + v;
+		it("adds a listener through onchange", function (done) {
+			createMQL(function (mql) {
+				var _event;
+				mql.onchange = function (event) {
+					_event = event;
+				};
+
+				triggerMQLEvent(mql);
+				waitForChangesReported(function () {
+					try {
+						proclaim.ok(_event);
+						proclaim.equal(_event.media, mql.media);
+						proclaim.equal(_event.matches, mql.matches);
+						done();
+					} catch (err) {
+						done(err);
 					}
 				});
+			}, done);
+		});
 
-				a.t = 1;
-				return (a.t === 2);
-			} catch (e) {
-				return false;
-			}
-		}())) {
-			it("adds a listener through onchange", function (done) {
-				createMQL(function (mql) {
-					var _event;
-					mql.onchange = function (event) {
-						_event = event;
-					};
+		it("removes a listener through onchange", function (done) {
+			createMQL(function (mql) {
+				var calls = 0;
+				mql.onchange = function () {
+					calls++;
+				};
 
-					triggerMQLEvent(mql);
-					waitForChangesReported(function () {
-						try {
-							proclaim.ok(_event);
-							proclaim.equal(_event.media, mql.media);
-							proclaim.equal(_event.matches, mql.matches);
-							done();
-						} catch (err) {
-							done(err);
-						}
-					});
-				}, done);
-			});
+				triggerMQLEvent(mql);
+				waitForChangesReported(function () {
+					try {
+						proclaim.equal(calls, 1);
 
-			it("removes a listener through onchange", function (done) {
-				createMQL(function (mql) {
-					var calls = 0;
-					mql.onchange = function () {
-						calls++;
-					};
+						mql.onchange = null;
 
-					triggerMQLEvent(mql);
-					waitForChangesReported(function () {
-						try {
-							proclaim.equal(calls, 1);
+						triggerMQLEvent(mql);
+						waitForChangesReported(function () {
+							try {
+								proclaim.equal(calls, 1);
+								done();
+							} catch (err) {
+								done(err);
+							}
+						});
 
-							mql.onchange = null;
+					} catch (err) {
+						done(err);
+					}
+				});
+			}, done);
+		});
 
-							triggerMQLEvent(mql);
-							waitForChangesReported(function () {
-								try {
-									proclaim.equal(calls, 1);
-									done();
-								} catch (err) {
-									done(err);
-								}
-							});
+		it("does not remove an onchange listener through removeEventListener", function (done) {
+			createMQL(function (mql) {
+				var calls = 0;
+				mql.onchange = function () {
+					calls++;
+				};
 
-						} catch (err) {
-							done(err);
-						}
-					});
-				}, done);
-			});
+				mql.removeEventListener('change', mql.onchange);
 
-			it("does not remove an onchange listener through removeEventListener", function (done) {
-				createMQL(function (mql) {
-					var calls = 0;
-					mql.onchange = function () {
-						calls++;
-					};
-
-					mql.removeEventListener('change', mql.onchange);
-
-					triggerMQLEvent(mql);
-					waitForChangesReported(function () {
-						try {
-							proclaim.equal(calls, 1);
-							done();
-						} catch (err) {
-							done(err);
-						}
-					});
-				}, done);
-			});
-		}
+				triggerMQLEvent(mql);
+				waitForChangesReported(function () {
+					try {
+						proclaim.equal(calls, 1);
+						done();
+					} catch (err) {
+						done(err);
+					}
+				});
+			}, done);
+		});
 	});
 } else {
 	describe('WPT (with polyfilled matchMedia)', function () {
@@ -439,49 +417,27 @@ if (typeof (self.matchMedia('(min-width: 1px)').listeners) === 'undefined') {
 			proclaim.equal(mql.listeners.length, 0);
 		});
 
-		if ((function () {
-			// supports setters (not IE8)
-			try {
-				var a = {};
-				Object.defineProperty(a, 't', {
-					configurable: true,
-					enumerable: false,
-					get: function () {
-						return this._v;
-					},
-					set: function (v) {
-						this._v = v + v;
-					}
-				});
+		it("adds a listener through onchange", function () {
+			var mql = window.matchMedia('(min-width: 1px)');
+			var listener = function () {
+					/* noop */
+				};
 
-				a.t = 1;
-				return (a.t === 2);
-			} catch (e) {
-				return false;
-			}
-		}())) {
-			it("adds a listener through onchange", function () {
-				var mql = window.matchMedia('(min-width: 1px)');
-				var listener = function () {
-						/* noop */
-					};
+			mql.onchange = listener;
 
-				mql.onchange = listener;
+			proclaim.equal(mql.listeners.length, 1);
+		});
 
-				proclaim.equal(mql.listeners.length, 1);
-			});
+		it("does not remove an onchange listener through removeEventListener", function () {
+			var mql = window.matchMedia('(min-width: 1px)');
+			var listener = function () {
+					/* noop */
+				};
 
-			it("does not remove an onchange listener through removeEventListener", function () {
-				var mql = window.matchMedia('(min-width: 1px)');
-				var listener = function () {
-						/* noop */
-					};
+			mql.onchange = listener;
+			mql.removeEventListener('change', listener);
 
-				mql.onchange = listener;
-				mql.removeEventListener('change', listener);
-
-				proclaim.equal(mql.listeners.length, 1);
-			});
-		}
+			proclaim.equal(mql.listeners.length, 1);
+		});
 	});
 }

--- a/polyfills/Node/prototype/contains/tests.js
+++ b/polyfills/Node/prototype/contains/tests.js
@@ -10,9 +10,7 @@ describe('on an element', function () {
 	detached = document.createElement('div');
 
 	it('is a function', function () {
-
-		// Asserting using to.be.a('function') in this case causes a hard browser crash in IE6
-		proclaim.isInstanceOf(documentElement.contains, Function);
+		proclaim.isFunction(documentElement.contains);
 	});
 
 	it('functions correctly', function () {

--- a/polyfills/Node/prototype/isSameNode/tests.js
+++ b/polyfills/Node/prototype/isSameNode/tests.js
@@ -10,9 +10,7 @@ describe('on an element', function () {
 	detached = document.createElement('div');
 
 	it('is a function', function () {
-
-		// Asserting using to.be.a('function') in this case causes a hard browser crash in IE6
-		proclaim.isInstanceOf(documentElement.isSameNode, Function);
+		proclaim.isFunction(documentElement.isSameNode);
 	});
 
 	it('functions correctly', function () {

--- a/polyfills/Number/parseFloat/polyfill.js
+++ b/polyfills/Number/parseFloat/polyfill.js
@@ -1,17 +1,13 @@
 /* global CreateMethodProperty */
 (function (nativeparseFloat, global) {
+	// Polyfill.io - parseFloat is incorrect in older browsers
 	var parseFloat = function parseFloat(str) {
 		var string = String(str).trim();
 		var result = nativeparseFloat(string);
 		return result === 0 && string.charAt(0) == '-' ? -0 : result;
 	}
-	try {
-		CreateMethodProperty(global, 'parseFloat', parseFloat);
-	} catch (e) {
-		// IE8 throws an error here if we set enumerable to false.
-		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global.parseFloat = parseFloat;
-	}
+	CreateMethodProperty(global, 'parseFloat', parseFloat);
+
 	// 20.1.2.12. Number.parseFloat ( string )
 	// The value of the Number.parseFloat data property is the same built-in function object that is the value of the  parseFloat property of the global object defined in 18.2.4.
 	CreateMethodProperty(Number, 'parseFloat', global.parseFloat);

--- a/polyfills/Number/parseInt/polyfill.js
+++ b/polyfills/Number/parseInt/polyfill.js
@@ -1,17 +1,12 @@
 /* global CreateMethodProperty */
 (function (nativeParseInt, global) {
-	// Polyfill.io - IE 8's parseInt is incorrect
+	// Polyfill.io - parseInt is incorrect in older browsers
 	var parseInt = function parseInt(str, radix) {
 		var string = String(str).trim();
 		return nativeParseInt(string, (radix >>> 0) || (/^[-+]?0[xX]/.test(string) ? 16 : 10));
 	}
-	try {
-		CreateMethodProperty(global, 'parseInt', parseInt);
-	} catch (e) {
-		// IE8 throws an error here if we set enumerable to false.
-		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global.parseInt = parseInt;
-	}
+	CreateMethodProperty(global, 'parseInt', parseInt);
+
 	// 20.1.2.13. Number.parseInt ( string, radix )
 	// The value of the Number.parseInt data property is the same built-in function object that is the value of the  parseInt property of the global object defined in 18.2.5.
 	CreateMethodProperty(Number, 'parseInt', global.parseInt);

--- a/polyfills/Object/create/tests.js
+++ b/polyfills/Object/create/tests.js
@@ -189,23 +189,7 @@ describe('Object.create', function () {
 		proclaim.ok(Object.create(new fn) instanceof fn);
 	});
 
-	if ('getPrototypeOf' in Object && (function () {
-		// supports getters (not IE8)
-		try {
-			var a = {};
-			Object.defineProperty(a, 't', {
-				configurable: true,
-				enumerable: false,
-				get: function () {
-					return true;
-				},
-				set: undefined
-			});
-			return !!a.t;
-		} catch (e) {
-			return false;
-		}
-	}())) {
+	if ('getPrototypeOf' in Object) {
 		it('can get the prototype of', function () {
 			function fn() {
 				return this.a = 1;

--- a/polyfills/Object/defineProperty/config.toml
+++ b/polyfills/Object/defineProperty/config.toml
@@ -9,9 +9,7 @@ aliases = [
 	"blissfuljs"
 ]
 dependencies = [ ]
-notes = [
-	"In browsers that have no hooks to define getter functions (notably IE <= 8), attempting to defineProperty with a getter or setter function will fail.  Since failing silently would likely break your application, we throw an exception.  In IE8, this can be hard to diagnose because the console will just say 'Exception thrown and not caught'"
-]
+notes = [ ]
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty"
 
 [browsers]

--- a/polyfills/Object/defineProperty/detect.js
+++ b/polyfills/Object/defineProperty/detect.js
@@ -1,11 +1,1 @@
-// In IE8, defineProperty could only act on DOM elements, so full support
-// for the feature requires the ability to set a property on an arbitrary object
-'defineProperty' in Object && (function() {
-	try {
-		var a = {};
-		Object.defineProperty(a, 'test', {value:42});
-		return true;
-	} catch(e) {
-		return false
-	}
-}())
+'defineProperty' in Object

--- a/polyfills/Object/entries/polyfill.js
+++ b/polyfills/Object/entries/polyfill.js
@@ -8,7 +8,7 @@
 	CreateMethodProperty(Object, 'entries', function entries(O) {
 		// 1. Let obj be ? ToObject(O).
 		var obj = ToObject(O);
-		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents
 		obj = (Type(obj) === 'string' || obj instanceof String) && toString.call(O) == '[object String]' ? split.call(O, '') : Object(O);
 		// 2. Let nameList be ? EnumerableOwnProperties(obj, "key+value").
 		var nameList = EnumerableOwnProperties(obj, "key+value");

--- a/polyfills/Object/entries/tests.js
+++ b/polyfills/Object/entries/tests.js
@@ -24,18 +24,14 @@ it('is not enumerable', function () {
 
 var arePropertyDescriptorsSupported = function() {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', {
-			enumerable: false,
-			value: obj
-		});
-		for (var _ in obj) {
-			return false;
-		}
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
+	Object.defineProperty(obj, 'x', {
+		enumerable: false,
+		value: obj
+	});
+	for (var _ in obj) {
 		return false;
 	}
+	return obj.x === obj;
 };
 
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();

--- a/polyfills/Object/getOwnPropertyDescriptor/polyfill.js
+++ b/polyfills/Object/getOwnPropertyDescriptor/polyfill.js
@@ -21,7 +21,7 @@
 	CreateMethodProperty(Object, 'getOwnPropertyDescriptor', function getOwnPropertyDescriptor(O, P) {
 		// 1. Let obj be ? ToObject(O).
 		var obj = ToObject(O);
-		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents
 		obj = (Type(obj) === 'string' || obj instanceof String) && toString.call(O) == '[object String]' ? split.call(O, '') : Object(O);
 
 		// 2. Let key be ? ToPropertyKey(P).

--- a/polyfills/Object/getOwnPropertyNames/polyfill.js
+++ b/polyfills/Object/getOwnPropertyNames/polyfill.js
@@ -24,7 +24,7 @@
 				}
 			}
 
-			// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+			// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents
 			object =
 				toString.call(object) == "[object String]"
 					? split.call(object, "")

--- a/polyfills/Object/setPrototypeOf/polyfill.js
+++ b/polyfills/Object/setPrototypeOf/polyfill.js
@@ -10,7 +10,6 @@
   //
   // NOTE:  This might need es5-shim or polyfills upfront
   //        because it's based on ES5 API.
-  //        (probably just an IE <= 8 problem)
   //
   // NOTE:  nodejs is fine in version 0.8, 0.10, and future versions.
 (function () {

--- a/polyfills/Object/values/polyfill.js
+++ b/polyfills/Object/values/polyfill.js
@@ -5,7 +5,7 @@
 	// 19.1.2.21. Object.values ( O )
 	CreateMethodProperty(Object, 'values', function values(O) {
 		// 1. Let obj be ? ToObject(O).
-		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+		// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents
 		var obj = toString.call(O) == '[object String]' ? split.call(O, '') : ToObject(O);
 		// 2. Let nameList be ? EnumerableOwnProperties(obj, "value").
 		var nameList = Object.keys(obj).map(function (key) {

--- a/polyfills/RegExp/prototype/@@matchAll/polyfill.js
+++ b/polyfills/RegExp/prototype/@@matchAll/polyfill.js
@@ -24,7 +24,7 @@ CreateMethodProperty(RegExp.prototype, Symbol.matchAll, function (string) {
 	var C = SpeciesConstructor(R, RegExp);
 	// 5. Let flags be ? ToString(? Get(R, "flags")).
 	var flags = ToString(Get(R, 'flags'));
-	// IE8 doesn't have RegExp.prototype.flags support
+	// IE doesn't have RegExp.prototype.flags support
 	if (!('flags' in RegExp.prototype)) {
 		flags = '';
 		if (R.global === true) {

--- a/polyfills/RegExp/prototype/flags/tests.js
+++ b/polyfills/RegExp/prototype/flags/tests.js
@@ -15,18 +15,14 @@ it('is a getter', function () {
 
 var arePropertyDescriptorsSupported = function() {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', {
-			enumerable: false,
-			value: obj
-		});
-		for (var _ in obj) {
-			return false;
-		}
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
+	Object.defineProperty(obj, 'x', {
+		enumerable: false,
+		value: obj
+	});
+	for (var _ in obj) {
 		return false;
 	}
+	return obj.x === obj;
 };
 
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();

--- a/polyfills/String/prototype/codePointAt/tests.js
+++ b/polyfills/String/prototype/codePointAt/tests.js
@@ -19,13 +19,9 @@ it('is not enumerable', function () {
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var ifSupportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported() ? it : xit;
 

--- a/polyfills/String/prototype/matchAll/polyfill.js
+++ b/polyfills/String/prototype/matchAll/polyfill.js
@@ -14,7 +14,7 @@ CreateMethodProperty(String.prototype, 'matchAll', function matchAll(regexp) {
 			// 2.b.i. Let flags be ? Get(regexp, "flags").
 			var flags = Get(regexp, "flags");
 
-			// IE8 doesn't have RegExp.prototype.flags support, it does have RegExp.prototype.global
+			// IE doesn't have RegExp.prototype.flags support, it does have RegExp.prototype.global
 			// 2.b.iii. If ? ToString(flags) does not contain "g", throw a TypeError exception.
 			if (!('flags' in RegExp.prototype) && regexp.global !== true) {
 				throw TypeError('');

--- a/polyfills/String/prototype/replaceAll/config.toml
+++ b/polyfills/String/prototype/replaceAll/config.toml
@@ -65,7 +65,7 @@ notes = [
 # - samsung_mob
 # The browser list uses a form of semantic versioning to indicate which browser requires polyfilling.
 # If all versions of a browser require the polyfill you can use the wildcard asterisk (*):
-# For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 8 and below you can use "<9"
+# For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 10 and below you can use "<11"
 [browsers]
 android = "*"
 bb = "*"

--- a/polyfills/String/prototype/replaceAll/polyfill.js
+++ b/polyfills/String/prototype/replaceAll/polyfill.js
@@ -14,7 +14,7 @@ CreateMethodProperty(String.prototype, 'replaceAll', function replaceAll(searchV
 			// 2.b.i. Let flags be ? Get(searchValue, "flags").
 			var flags = Get(searchValue, "flags");
 
-			// IE8 doesn't have RegExp.prototype.flags support, it does have RegExp.prototype.global
+			// IE doesn't have RegExp.prototype.flags support, it does have RegExp.prototype.global
 			// 2.b.iii. If ? ToString(flags) does not contain "g", throw a TypeError exception.
 			if (!('flags' in RegExp.prototype) && searchValue.global !== true) {
 				throw TypeError('');

--- a/polyfills/String/prototype/replaceAll/tests.js
+++ b/polyfills/String/prototype/replaceAll/tests.js
@@ -123,22 +123,12 @@ describe('String.prototype.replaceAll', function () {
 				proclaim.deepStrictEqual(result, 'aa z z aa');
 			}
 
-			// IE8 reorders flags when converting a RegExp to string.
-			if ((/./gi).toString() === "/./ig") {
-				searchValue = /./gi;
+			searchValue = /./gi;
 
-				Object.defineProperty(searchValue, self.Symbol.replace, { value: undefined });
+			Object.defineProperty(searchValue, self.Symbol.replace, { value: undefined });
 
-				result = 'aa /./ig /./ig aa'.replaceAll(searchValue, 'z');
-				proclaim.deepStrictEqual(result, 'aa z z aa');
-			} else {
-				searchValue = /./gi;
-
-				Object.defineProperty(searchValue, self.Symbol.replace, { value: undefined });
-
-				result = 'aa /./gi /./gi aa'.replaceAll(searchValue, 'z');
-				proclaim.deepStrictEqual(result, 'aa z z aa');
-			}
+			result = 'aa /./gi /./gi aa'.replaceAll(searchValue, 'z');
+			proclaim.deepStrictEqual(result, 'aa z z aa');
 
 			if (supportsRegexpStickyFlag) {
 				searchValue = new RegExp('\\.', 'igy');

--- a/polyfills/Symbol/asyncIterator/tests.js
+++ b/polyfills/Symbol/asyncIterator/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/hasInstance/tests.js
+++ b/polyfills/Symbol/hasInstance/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/isConcatSpreadable/tests.js
+++ b/polyfills/Symbol/isConcatSpreadable/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/iterator/tests.js
+++ b/polyfills/Symbol/iterator/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/match/tests.js
+++ b/polyfills/Symbol/match/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/matchAll/tests.js
+++ b/polyfills/Symbol/matchAll/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/polyfill.js
+++ b/polyfills/Symbol/polyfill.js
@@ -5,24 +5,6 @@
 (function (Object,  GOPS, global) {
 	'use strict'; //so that ({}).toString.call(null) returns the correct [object Null] rather than [object Window]
 
-	var supportsGetters = (function () {
-		// supports getters
-		try {
-			var a = {};
-			Object.defineProperty(a, "t", {
-				configurable: true,
-				enumerable: false,
-				get: function () {
-					return true;
-				},
-				set: undefined
-			});
-			return !!a.t;
-		} catch (e) {
-			return false;
-		}
-	}());
-
 	var	setDescriptor;
 	var id = 0;
 	var random = '' + Math.random();
@@ -179,15 +161,6 @@
 		}
 
 		var that = setAndGetSymbol(uid);
-
-		if (!supportsGetters) {
-			Object.defineProperty(that, "description", {
-				configurable: true,
-				enumerable: false,
-				value: symbolDescription(that)
-			});
-		}
-
 		return that;
 	};
 

--- a/polyfills/Symbol/prototype/description/polyfill.js
+++ b/polyfills/Symbol/prototype/description/polyfill.js
@@ -1,27 +1,6 @@
 /* global Symbol, Type, Proxy */
 
 (function (global) {
-	var supportsGetters = (function() {
-		try {
-			var a = {};
-			Object.defineProperty(a, "t", {
-				configurable: true,
-				enumerable: false,
-				get: function() {
-					return true;
-				},
-				set: undefined
-			});
-			return !!a.t;
-		} catch (e) {
-			return false;
-		}
-	})();
-
-	if (!supportsGetters) {
-		return;
-	}
-
 	function isSymbolPolyfilled(symbol) {
 		return symbol.toString().indexOf("__\x01symbol:") === 0;
 	}

--- a/polyfills/Symbol/replace/tests.js
+++ b/polyfills/Symbol/replace/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/search/tests.js
+++ b/polyfills/Symbol/search/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/species/tests.js
+++ b/polyfills/Symbol/species/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/split/tests.js
+++ b/polyfills/Symbol/split/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -19,13 +19,9 @@ it('is not enumerable', function () {
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 var strictModeSupported = (function(){ return this; }).call(null) === null;
@@ -240,44 +236,19 @@ it('does not break when an iframe is added', function () {
 // Match tests for "Polyfill.prototype.description"
 // The polyfill for this feature is done separately for modern browsers, but also here in the Symbol polyfill.
 describe('Polyfill.prototype.description', function () {
-	var supportsGetters = (function () {
-		// supports getters
-		try {
-			var a = {};
-			Object.defineProperty(a, "t", {
-				configurable: true,
-				enumerable: false,
-				get: function () {
-					return true;
-				},
-				set: undefined
-			});
-			return !!a.t;
-		} catch (e) {
-			return false;
+	it('is defined', function () {
+		proclaim.include(Symbol.prototype, 'description');
+	});
+
+	it('is not enumerable', function () {
+		proclaim.isNotEnumerable(Symbol.prototype, 'description');
+	});
+
+	it('is configurable', function () {
+		if (Object.getOwnPropertyDescriptor) {
+			proclaim.isTrue(Object.getOwnPropertyDescriptor(Symbol.prototype, 'description').configurable);
 		}
-	}());
-
-	if (supportsGetters) {
-		it('is defined', function () {
-			proclaim.include(Symbol.prototype, 'description');
-		});
-
-		it('is not enumerable', function () {
-			proclaim.isNotEnumerable(Symbol.prototype, 'description');
-		});
-
-		it('is configurable', function () {
-			if (Object.getOwnPropertyDescriptor) {
-				proclaim.isTrue(Object.getOwnPropertyDescriptor(Symbol.prototype, 'description').configurable);
-			}
-		});
-	} else {
-		it('is defined', function () {
-			var s = Symbol('foo');
-			proclaim.ok('description' in s);
-		});
-	}
+	});
 
 	it('works with strings', function () {
 		proclaim.strictEqual(Symbol("hello").description, "hello");

--- a/polyfills/Symbol/toPrimitive/tests.js
+++ b/polyfills/Symbol/toPrimitive/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/toStringTag/tests.js
+++ b/polyfills/Symbol/toStringTag/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/Symbol/unscopables/tests.js
+++ b/polyfills/Symbol/unscopables/tests.js
@@ -3,13 +3,9 @@
 
 var arePropertyDescriptorsSupported = function () {
 	var obj = {};
-	try {
-		Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+	Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
 	for (var _ in obj) { return false; }
-		return obj.x === obj;
-	} catch (e) { // this is IE 8.
-		return false;
-	}
+	return obj.x === obj;
 };
 var supportsDescriptors = Object.defineProperty && arePropertyDescriptorsSupported();
 

--- a/polyfills/TypedArray/prototype/at/polyfill.js
+++ b/polyfills/TypedArray/prototype/at/polyfill.js
@@ -1,20 +1,8 @@
-/* global CreateMethodProperty, Uint8Array, ToIntegerOrInfinity, ToString */
+/* global CreateMethodProperty, ToIntegerOrInfinity, ToString */
 // 23.2.3.1. %TypedArray%.prototype.at ( index )
 (function () {
-	// In Internet Explorer 8 there is no support for square-bracket notation
-	// in the TypedArrays polyfill instead so we need to use the private `_getter` method
-	var typedArraysSupportIndexLookup = (function() {
-		var uint8 = new Uint8Array(2);
-		uint8[0] = 42;
-		return uint8[0] === 42
-	})
-
 	function getTypedArrayIndex(array, index) {
-		if (typedArraysSupportIndexLookup) {
-			return array[index];
-		} else {
-			return array._getter(index);
-		}
+		return array[index];
 	}
 
 	function at(index) {

--- a/polyfills/TypedArray/prototype/at/tests.js
+++ b/polyfills/TypedArray/prototype/at/tests.js
@@ -24,39 +24,18 @@ it('is not enumerable', function () {
 });
 
 describe('at', function () {
-	var supportsGetters = (function() {
-		try {
-			var a = {};
-			Object.defineProperty(a, "t", {
-				configurable: true,
-				enumerable: false,
-				get: function() {
-					return true;
-				},
-				set: undefined
-			});
-			return !!a.t;
-		} catch (e) {
-			return false;
-		}
-	})();
-
-	// `new Int8Array(length)` fails with "Getters & setters cannot be defined on this javascript engine" in IE8
-	// due to a bug in the `ArrayBuffer` polyfill: https://github.com/inexorabletash/polyfill/issues/23
-	if (supportsGetters) {
-		it('retrieves values by index for typed arrays', function () {
-			var typedArray = new Int8Array(3);
-			typedArray[0] = 1;
-			typedArray[1] = 2;
-			typedArray[2] = 3;
-			proclaim.equal(typedArray.at(undefined), 1);
-			proclaim.equal(typedArray.at(-4), undefined);
-			proclaim.equal(typedArray.at(-2), 2);
-			proclaim.equal(typedArray.at(-0.5), 1);
-			proclaim.equal(typedArray.at(0), 1);
-			proclaim.equal(typedArray.at(0.5), 1);
-			proclaim.equal(typedArray.at(2), 3);
-			proclaim.equal(typedArray.at(4), undefined);
-		});
-	}
+	it('retrieves values by index for typed arrays', function () {
+		var typedArray = new Int8Array(3);
+		typedArray[0] = 1;
+		typedArray[1] = 2;
+		typedArray[2] = 3;
+		proclaim.equal(typedArray.at(undefined), 1);
+		proclaim.equal(typedArray.at(-4), undefined);
+		proclaim.equal(typedArray.at(-2), 2);
+		proclaim.equal(typedArray.at(-0.5), 1);
+		proclaim.equal(typedArray.at(0), 1);
+		proclaim.equal(typedArray.at(0.5), 1);
+		proclaim.equal(typedArray.at(2), 3);
+		proclaim.equal(typedArray.at(4), undefined);
+	});
 });

--- a/polyfills/URL/config.toml
+++ b/polyfills/URL/config.toml
@@ -14,7 +14,7 @@ dependencies = [
 	"Array.from",
 	"Symbol.iterator"
 ]
-notes = [ "Polyfill requires Object getters so fails in IE <= 8" ]
+notes = [ ]
 license = "CC0-1.0"
 repo = "https://github.com/inexorabletash/polyfill"
 docs = "https://developer.mozilla.org/en-US/docs/Web/API/URL"

--- a/polyfills/URL/polyfill.js
+++ b/polyfills/URL/polyfill.js
@@ -4,7 +4,7 @@
 
 // Notes:
 // - Primarily useful for parsing URLs and modifying query parameters
-// - Should work in IE8+ and everything more modern, with es5.js polyfills
+// - Should work in IE9+ and everything more modern, with es5.js polyfills
 
 (function (global) {
 	'use strict';
@@ -351,27 +351,11 @@
 
 			// An inner object implementing URLUtils (either a native URL
 			// object or an HTMLAnchorElement instance) is used to perform the
-			// URL algorithms. With full ES5 getter/setter support, return a
-			// regular object For IE8's limited getter/setter support, a
-			// different HTMLAnchorElement is returned with properties
-			// overridden
+			// URL algorithms.
 
 			var instance = URLUtils(url || '');
 
-			// Detect for ES5 getter/setter support
-			// (an Object.defineProperties polyfill that doesn't support getters/setters may throw)
-			var ES5_GET_SET = (function() {
-				if (!('defineProperties' in Object)) return false;
-				try {
-					var obj = {};
-					Object.defineProperties(obj, { prop: { get: function () { return true; } } });
-					return obj.prop;
-				} catch (_) {
-					return false;
-				}
-			}());
-
-			var self = ES5_GET_SET ? this : document.createElement('a');
+			var self = this;
 
 
 

--- a/polyfills/WeakMap/polyfill.js
+++ b/polyfills/WeakMap/polyfill.js
@@ -77,9 +77,7 @@
 		} catch (e) {
 			// Polyfill.io - For user agents which do not have iteration methods on argument objects or arrays, we can special case those.
 			if (Array.isArray(iterable) ||
-				Object.prototype.toString.call(iterable) === '[object Arguments]' ||
-				// IE 7 & IE 8 return '[object Object]' for the arguments object, we can detect by checking for the existence of the callee property
-				(!!iterable.callee)) {
+				Object.prototype.toString.call(iterable) === '[object Arguments]') {
 				var index;
 				var length = iterable.length;
 				for (index = 0; index < length; index++) {
@@ -260,11 +258,5 @@
 	}
 
 	// Export the object
-	try {
-		CreateMethodProperty(global, 'WeakMap', WeakMap);
-	} catch (e) {
-		// IE8 throws an error here if we set enumerable to false.
-		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global.WeakMap = WeakMap;
-	}
+	CreateMethodProperty(global, 'WeakMap', WeakMap);
 }(self));

--- a/polyfills/WeakSet/polyfill.js
+++ b/polyfills/WeakSet/polyfill.js
@@ -55,9 +55,7 @@
 		} catch (e) {
 			// Polyfill.io - For user agents which do not have iteration methods on argument objects or arrays, we can special case those.
 			if (IsArray(iterable) ||
-				Object.prototype.toString.call(iterable) === '[object Arguments]' ||
-				// IE 7 & IE 8 return '[object Object]' for the arguments object, we can detect by checking for the existence of the callee property
-				(!!iterable.callee)) {
+				Object.prototype.toString.call(iterable) === '[object Arguments]') {
 				var index;
 				var length = iterable.length;
 				for (index = 0; index < length; index++) {
@@ -193,12 +191,5 @@
 	}
 
 	// Export the object
-	try {
-		CreateMethodProperty(global, 'WeakSet', WeakSet);
-	} catch (e) {
-		// IE8 throws an error here if we set enumerable to false.
-		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		global.WeakSet = WeakSet;
-	}
-
+	CreateMethodProperty(global, 'WeakSet', WeakSet);
 }(self));

--- a/polyfills/_ESAbstract/AddEntriesFromIterable/polyfill.js
+++ b/polyfills/_ESAbstract/AddEntriesFromIterable/polyfill.js
@@ -31,7 +31,7 @@ var AddEntriesFromIterable = (function() {
 				IteratorClose(iteratorRecord, error);
 				throw error;
 			}
-			// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents (IE 8)
+			// Polyfill.io fallback for non-array-like strings which exist in some ES3 user-agents
 			nextItem =
 				(Type(nextItem) === "string" || nextItem instanceof String) &&
 				toString.call(nextItem) == "[object String]"

--- a/polyfills/atob/tests.js
+++ b/polyfills/atob/tests.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha, browser */
 /* global proclaim */
 
-// Doesn't throw in IE6, otherwise works fine, so tolerate this
+// Doesn't throw in IE9, otherwise works fine, so tolerate this
 it.skip("should throw exception for invalid characters in code", function () {
 	proclaim["throws"](function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3$VyZ");
 	});
 });
 
-// Doesn't throw in IE6, otherwise works fine, so tolerate this
+// Doesn't throw in IE9, otherwise works fine, so tolerate this
 it.skip("should throw exception for too much padding", function () {
 	proclaim["throws"](function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3VyZ===");

--- a/polyfills/document/elementsFromPoint/config.toml
+++ b/polyfills/document/elementsFromPoint/config.toml
@@ -50,7 +50,7 @@ license = "MIT"
 # - samsung_mob
 # The browser list uses a form of semantic versioning to indicate which browser requires polyfilling.
 # If all versions of a browser require the polyfill you can use the wildcard asterisk (*):
-# For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 8 and below you can use "<9"
+# For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 10 and below you can use "<11"
 [browsers]
 android = "<53"
 bb = "*"

--- a/polyfills/document/elementsFromPoint/polyfill.js
+++ b/polyfills/document/elementsFromPoint/polyfill.js
@@ -6,7 +6,7 @@ document.elementsFromPoint = function elementsFromPoint(x, y) {
 	var stack = [];
 	var element = document.elementFromPoint(x, y);
 
-	// IE8 and IE9 don't have support for pointer-events for html elements
+	// IE9 doesn't have support for pointer-events for html elements
 	var isIE =  (/msie|trident/i).test(navigator && navigator.userAgent);
 	// CSS property used to exclude the element from hit testing
 	var propertyName = isIE
@@ -23,8 +23,6 @@ document.elementsFromPoint = function elementsFromPoint(x, y) {
 			element.style.setProperty(name, value, priority);
 		} else {
 			element.style[name] = value;
-			// need to force a reflow on IE8 in some cases
-			element.getClientRects();
 		}
 	}
 

--- a/polyfills/document/polyfill.js
+++ b/polyfills/document/polyfill.js
@@ -1,14 +1,5 @@
 if ((typeof WorkerGlobalScope === "undefined") && (typeof importScripts !== "function")) {
-
-	if (self.HTMLDocument) { // IE8
-
-		// HTMLDocument is an extension of Document.  If the browser has HTMLDocument but not Document, the former will suffice as an alias for the latter.
-		self.Document = self.HTMLDocument;
-
-	} else {
-
-		// Create an empty function to act as the missing constructor for the document object, attach the document object as its prototype.  The function needs to be anonymous else it is hoisted and causes the feature detect to prematurely pass, preventing the assignments below being made.
-		self.Document = self.HTMLDocument = document.constructor = (new Function('return function Document() {}')());
-		self.Document.prototype = document;
-	}
+	// Create an empty function to act as the missing constructor for the document object, attach the document object as its prototype.  The function needs to be anonymous else it is hoisted and causes the feature detect to prematurely pass, preventing the assignments below being made.
+	self.Document = self.HTMLDocument = document.constructor = (new Function('return function Document() {}')());
+	self.Document.prototype = document;
 }

--- a/polyfills/globalThis/polyfill.js
+++ b/polyfills/globalThis/polyfill.js
@@ -45,16 +45,10 @@
 		Function("return this")();
 
 	// Export the object
-	try {
-		Object.defineProperty(globalThis, "globalThis", {
-			configurable: true,
-			enumerable: false,
-			writable: true,
-			value: globalThis
-		});
-	} catch (e) {
-		// IE8 throws an error here if we set enumerable to false.
-		// More info on table 2: https://msdn.microsoft.com/en-us/library/dd229916(v=vs.85).aspx
-		globalThis.globalThis = globalThis;
-	}
+	Object.defineProperty(globalThis, "globalThis", {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: globalThis
+	});
 })();

--- a/polyfills/globalThis/tests.js
+++ b/polyfills/globalThis/tests.js
@@ -4,21 +4,16 @@
 describe("globalThis", function() {
 	var arePropertyDescriptorsSupported = function() {
 		var obj = {};
-		try {
-			Object.defineProperty(obj, "x", {
-				enumerable: false,
-				value: obj
-			});
-			/* eslint-disable no-unused-vars, no-restricted-syntax */
-			for (var _ in obj) {
-				return false;
-			}
-			/* eslint-enable no-unused-vars, no-restricted-syntax */
-			return obj.x === obj;
-		} catch (e) {
-			// this is IE 8.
+		Object.defineProperty(obj, "x", {
+			enumerable: false,
+			value: obj
+		});
+		/* eslint-disable no-unused-vars, no-restricted-syntax */
+		for (var _ in obj) {
 			return false;
 		}
+		/* eslint-enable no-unused-vars, no-restricted-syntax */
+		return obj.x === obj;
 	};
 
 	var supportsDescriptors =

--- a/polyfills/matchMedia/polyfill.js
+++ b/polyfills/matchMedia/polyfill.js
@@ -19,20 +19,14 @@
 		script.parentNode.insertBefore(style, script);
 		}
 
-		// 'style.currentStyle' is used by IE <= 8 and 'self.getComputedStyle' for all other browsers
-		info = ('getComputedStyle' in self) && self.getComputedStyle(style, null) || style.currentStyle;
+		info = ('getComputedStyle' in self) && self.getComputedStyle(style, null);
 
 		styleMedia = {
 			matchMedium: function(media) {
 				media = media.replace(/^only\s+/, '');
 				var text = '@media ' + media + '{ #matchmediajs-test { width: 1px; } }';
 
-				// 'style.styleSheet' is used by IE <= 8 and 'style.textContent' for all other browsers
-				if (style.styleSheet) {
-					style.styleSheet.cssText = text;
-				} else {
-					style.textContent = text;
-				}
+				style.textContent = text;
 
 				// Test if media query is true or false
 				return info.width === '1px';

--- a/polyfills/requestIdleCallback/polyfill.js
+++ b/polyfills/requestIdleCallback/polyfill.js
@@ -71,7 +71,7 @@
 		messageKey = 'polyfillIdleCallback' + Math.random().toString(36).slice(2);
 		port = window;
 		window.addEventListener('message', function (event) {
-			// IE8 returns true when a strict comparison with `window` is made.
+			// some engines return true when a strict comparison with `window` is made.
 			if (event.source != window || event.data !== messageKey) {
 				return;
 			}

--- a/polyfills/screen/orientation/config.toml
+++ b/polyfills/screen/orientation/config.toml
@@ -1,7 +1,5 @@
 dependencies = [ "Object.defineProperty" ]
-notes = [
-	"In IE <= 8 window.screen is read-only, so the orientation property is not definable"
-]
+notes = [ ]
 spec = "http://www.w3.org/TR/screen-orientation/"
 docs = "https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation"
 

--- a/tasks/buildsources/polyfill.js
+++ b/tasks/buildsources/polyfill.js
@@ -271,14 +271,10 @@ module.exports = class Polyfill {
 			const minified = uglify.minify(source, {
 				fromString: true,
 				compress: {
-					screw_ie8: false,
 					keep_fnames: true
 				},
-				mangle: {
-					screw_ie8: false
-				},
+				mangle: {},
 				output: {
-					screw_ie8: false,
 					beautify: false
 				}
 			});
@@ -314,15 +310,11 @@ module.exports = class Polyfill {
 			const minified = uglify.minify(source, {
 				fromString: true,
 				compress: {
-					screw_ie8: false,
 					expression: true,
 					keep_fnames: true
 				},
-				mangle: {
-					screw_ie8: false
-				},
+				mangle: {},
 				output: {
-					screw_ie8: false,
 					beautify: false,
 					semicolons: false
 				}

--- a/tasks/polyfill-templates/config.toml
+++ b/tasks/polyfill-templates/config.toml
@@ -48,7 +48,7 @@ license = ""
 # - samsung_mob
 # The browser list uses a form of semantic versioning to indicate which browser requires polyfilling.
 # If all versions of a browser require the polyfill you can use the wildcard asterisk (*):
-# For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 8 and below you can use "<9"
+# For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 10 and below you can use "<11"
 [browsers]
 android = "*"
 bb = "*"


### PR DESCRIPTION
This PR removes all workarounds required for IE 8 from polyfills:
* `supportsGetters` & `supportsSetters` checks
* `document.createEvent` vs. `new Event`
* `element.getClientRects()` in `document.elementsFromPoint`
* `arguments.callee` checks
* `unlistenableWindowEvents` in `Event`
* `HTMLPictureElement` detection

It also removes all mentions of IE 8 from documentation and comments.