### PR TITLE
Update `dot-notation` eslint rule to allow keywords

### DIFF
--- a/polyfills/.eslintrc
+++ b/polyfills/.eslintrc
@@ -12,7 +12,7 @@
 	"rules": {
 		"comma-dangle": ["error", "never"],
 		"quote-props": ["error", "as-needed", { "keywords": true }],
-		"dot-notation": ["error", { "allowKeywords": false }],
+		"dot-notation": ["error"],
 		"radix": "error",
 		"no-catch-shadow": "error",
 		"no-dupe-else-if": "error",

--- a/polyfills/AggregateError/tests.js
+++ b/polyfills/AggregateError/tests.js
@@ -55,7 +55,7 @@ describe('AggregateError', function () {
 	});
 
 	it("throws an error for input that is not iterable", function () {
-		proclaim['throws'](function () {
+		proclaim.throws(function () {
 			new AggregateError(0)
 		}, /is not iterable/);
 	});

--- a/polyfills/Array/from/tests.js
+++ b/polyfills/Array/from/tests.js
@@ -196,41 +196,41 @@ describe('returns an array with', function () {
 
 describe('throws', function () {
 	it('non-iterable objects', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from();
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from(undefined);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from(null);
 		});
 	});
 
 	it('specified, invalid mapping functions', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from([1, 2, 3], null);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from([1, 2, 3], /\*/);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from([1, 2, 3], '');
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from([1, 2, 3], []);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from([1, 2, 3], {});
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.from([1, 2, 3], 3);
 		});
 	});

--- a/polyfills/Array/prototype/copyWithin/tests.js
+++ b/polyfills/Array/prototype/copyWithin/tests.js
@@ -90,13 +90,13 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('throws if called with null context', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			return Array.prototype.copyWithin.call(null, 0);
 		}, TypeError);
 	});
 
 	it('throws if called with undefined context', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			return Array.prototype.copyWithin.call(undefined, 0);
 		}, TypeError);
 	});

--- a/polyfills/Array/prototype/flat/tests.js
+++ b/polyfills/Array/prototype/flat/tests.js
@@ -24,25 +24,25 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if constructor property is neither undefined nor an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = null;
 		a.flat();
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = 1;
 		a.flat();
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = 'string';
 		a.flat();
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = true;
 		a.flat();
@@ -51,24 +51,24 @@ it('throws a TypeError if constructor property is neither undefined nor an Objec
 
 if (supportsStrictModeTests) {
 	it('throws TypeError if thisArg is null', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			[].flat.call(null);
 		}, TypeError);
 	});
 	it('throws TypeError if thisArg is missing', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			[].flat.call();
 		}, TypeError);
 	});
 	it('throws TypeError if thisArg is undefined', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			[].flat.call(undefined);
 		}, TypeError);
 	});
 }
 if ('Symbol' in self) {
 	it('throws TypeError if argument is a Symbol', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			[].flat(Symbol());
 		}, TypeError);
 	});

--- a/polyfills/Array/prototype/flatMap/tests.js
+++ b/polyfills/Array/prototype/flatMap/tests.js
@@ -25,68 +25,68 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('throws TypeError if thisArg is null', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			[].flatMap.call(null, function () {});
 		}, TypeError);
 	});
 
 	it('throws TypeError if thisArg is undefined', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			[].flatMap.call(undefined, function () {});
 		}, TypeError);
 	});
 }
 
 it('throws TypeError if argument is not callable', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap({});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap(0);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap();
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap(undefined);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap(null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap(false);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		[].flatMap('');
 	}, TypeError);
 });
 
 it('throws a TypeError if constructor property is neither undefined nor an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = null;
 		a.flatMap(function () {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = 1;
 		a.flatMap(function () {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = 'string';
 		a.flatMap(function () {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		var a = [];
 		a.constructor = true;
 		a.flatMap(function () {});

--- a/polyfills/Array/prototype/includes/tests.js
+++ b/polyfills/Array/prototype/includes/tests.js
@@ -78,10 +78,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.prototype.includes.call(null, 0);
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Array.prototype.includes.call(void 8, 0);
 		}, TypeError);
 	}

--- a/polyfills/Blob/tests.js
+++ b/polyfills/Blob/tests.js
@@ -15,84 +15,84 @@ describe('Blob', function () {
 	});
 
 	it('throws an error if called without `new` operator', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Blob();
 		}, TypeError);
 	});
 
 	it('throws an error if called with null', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(null);
 		}, TypeError);
 	});
 
 	it('throws an error if called with true', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(true);
 		}, TypeError);
 	});
 
 	it('throws an error if called with false', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(false);
 		}, TypeError);
 	});
 
 	it('throws an error if called with 0', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(0);
 		}, TypeError);
 	});
 
 	it('throws an error if called with 1', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(1);
 		}, TypeError);
 	});
 
 	it('throws an error if called with decimal number', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(1.5);
 		}, TypeError);
 	});
 
 	it('throws an error if called with a string', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob('fail');
 		}, TypeError);
 	});
 
 	it('throws an error if called with a date', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(new Date());
 		}, TypeError);
 	});
 
 	it('throws an error if called with a RegExp', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(new RegExp());
 		}, TypeError);
 	});
 
 	// This requires rewriting the polyfill to take into account iterable objects defined via Symbol.iterator instead of being based on blobParts.length property
 	it.skip('throws an error if called with an object', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob({});
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob({ 0: 'fail', length: 1 });
 		}, TypeError);
 	});
 
 	it('throws an error if called with a div', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(document.createElement('div'));
 		}, TypeError);
 	});
 
 	// This requires rewriting the polyfill to take into account iterable objects defined via Symbol.iterator instead of being based on blobParts.length property
 	it.skip('throws an error if called with window', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob(window);
 		}, TypeError);
 	});
@@ -122,25 +122,25 @@ describe('Blob', function () {
 	});
 
 	it('should throw if second argument is an integer', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob([], 12345);
 		}, TypeError);
 	});
 
 	it('should throw if second argument is an decimal number', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob([], 1.2);
 		}, TypeError);
 	});
 
 	it('should throw if second argument is an boolean', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob([], true);
 		}, TypeError);
 	});
 
 	it('should throw if second argument is an string', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new Blob([], '12345');
 		}, TypeError);
 	});
@@ -225,7 +225,7 @@ describe('Blob', function () {
 				}).then(function (text) {
 					proclaim.equal(text, 'test');
 					done();
-				})["catch"](function (err1) {
+				}).catch(function (err1) {
 					done(err1);
 				});
 			} catch (err2) {

--- a/polyfills/CustomEvent/tests.js
+++ b/polyfills/CustomEvent/tests.js
@@ -11,7 +11,7 @@ it('should have an initCustomEvent function', function() {
 // Safari allows you to instantiate with no parameters, all this means is you create an event that you can never
 // listen for - pointless, but will not break anything...
 it.skip('should throw exception when instantiated with no parameters', function() {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		new CustomEvent();
 	});
 });

--- a/polyfills/Element/prototype/closest/tests.js
+++ b/polyfills/Element/prototype/closest/tests.js
@@ -75,7 +75,7 @@ if (!!document.createElementNS && !!document.createElementNS('http://www.w3.org/
 it.skip("should throw an error if the selector syntax is incorrect", function() {
 	var el = document.body.appendChild(document.createElement("a"));
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		el.closest("p<incorrectselector:><");
 	});
 

--- a/polyfills/Element/prototype/inert/polyfill.js
+++ b/polyfills/Element/prototype/inert/polyfill.js
@@ -213,7 +213,7 @@
 			value: function _unmanageNode(node) {
 				var inertNode = this._inertManager.deregister(node, this);
 				if (inertNode) {
-					this._managedNodes['delete'](inertNode);
+					this._managedNodes.delete(inertNode);
 				}
 			}
 
@@ -474,7 +474,7 @@
 			key: 'removeInertRoot',
 			value: function removeInertRoot(inertRoot) {
 				this._throwIfDestroyed();
-				this._inertRoots['delete'](inertRoot);
+				this._inertRoots.delete(inertRoot);
 				if (this._inertRoots.size === 0) {
 					this.destructor();
 				}
@@ -612,7 +612,7 @@
 
 					var _inertRoot = this._inertRoots.get(root);
 					_inertRoot.destructor();
-					this._inertRoots['delete'](root);
+					this._inertRoots.delete(root);
 					root.removeAttribute('inert');
 				}
 			}
@@ -674,7 +674,7 @@
 
 				inertNode.removeInertRoot(inertRoot);
 				if (inertNode.destroyed) {
-					this._managedNodes['delete'](node);
+					this._managedNodes.delete(node);
 				}
 
 				return inertNode;

--- a/polyfills/Element/prototype/toggleAttribute/tests.js
+++ b/polyfills/Element/prototype/toggleAttribute/tests.js
@@ -13,7 +13,7 @@ describe('Element.prototype.toggleAttribute', function() {
 	});
 
 	it("should throw an error if the attribute name is not valid", function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			el.toggleAttribute('$');
 		});
 	});

--- a/polyfills/Event/tests.js
+++ b/polyfills/Event/tests.js
@@ -5,7 +5,7 @@
 // as it would just create an event that can never be dispatched/listened for
 // it doesn't cause any problem
 it.skip('should throw exception when instantiated with no parameters', function() {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		new Event();
 	});
 });

--- a/polyfills/HTMLInputElement/prototype/valueAsDate/generated_tests.js
+++ b/polyfills/HTMLInputElement/prototype/valueAsDate/generated_tests.js
@@ -141,25 +141,25 @@ describe("HTMLInputElement.prototype.valueAsDate", function () {
 			var inputA = unsupportedInputsViaAttribute[type];
 			var inputB = unsupportedInputsViaProperty[type];
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputA, [
 					[null, ""]
 				]);
 			});
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputA, [
 					[new Date("2019-12-10T00:00:00.000Z"), ""]
 				]);
 			});
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputB, [
 					[null, ""]
 				]);
 			});
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputB, [
 					[new Date("2019-12-10T00:00:00.000Z"), ""]
 				]);

--- a/polyfills/HTMLInputElement/prototype/valueAsDate/tests.js
+++ b/polyfills/HTMLInputElement/prototype/valueAsDate/tests.js
@@ -132,25 +132,25 @@ describe("HTMLInputElement.prototype.valueAsDate", function () {
 			var inputA = unsupportedInputsViaAttribute[type];
 			var inputB = unsupportedInputsViaProperty[type];
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputA, [
 					[null, ""]
 				]);
 			});
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputA, [
 					[new Date("2019-12-10T00:00:00.000Z"), ""]
 				]);
 			});
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputB, [
 					[null, ""]
 				]);
 			});
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testValueAsDateSetter(inputB, [
 					[new Date("2019-12-10T00:00:00.000Z"), ""]
 				]);

--- a/polyfills/Map/config.toml
+++ b/polyfills/Map/config.toml
@@ -19,7 +19,6 @@ dependencies = [
 	"Object.isExtensible"
 ]
 notes = [
-	"For compatibility with very old engines, `Map.prototype.delete` must be accessed using square bracket notation because 'delete' is a reserved word. `myMap.delete()` is an error in IE8. Use `myMap['delete']()` instead.",
 	"The test suite for this polyfill is derived from work of Andrea Giammarchi which is [published under an MIT licence](https://github.com/WebReflection/es6-collections)"
 ]
 

--- a/polyfills/Map/tests.js
+++ b/polyfills/Map/tests.js
@@ -235,7 +235,7 @@ describe('Map', function () {
 		});
 
 		it('throws error if called without NewTarget set. I.E. Called as a normal function and not a constructor', function () {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map(); // eslint-disable-line new-cap
 			});
 		});
@@ -321,31 +321,31 @@ describe('Map', function () {
 		});
 
 		it('throws a TypeError if `this` is not an Object', function () {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call('');
 			}, TypeError);
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call(1);
 			}, TypeError);
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call(true);
 			}, TypeError);
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call(/ /);
 			}, TypeError);
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call(null);
 			}, TypeError);
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call(undefined);
 			}, TypeError);
 		});
 
 		it('throws a TypeError if `this` is not an a Map Object', function () {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call([]);
 			}, TypeError);
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				Map.prototype.clear.call({});
 			}, TypeError);
 		});
@@ -357,48 +357,48 @@ describe('Map', function () {
 
 	describe('Map.prototype.delete', function () {
 		it('has 1 length', function () {
-			proclaim.equal(Map.prototype['delete'].length, 1);
+			proclaim.equal(Map.prototype.delete.length, 1);
 		});
 
 		it('throws a TypeError if `this` is not an Object', function () {
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call('');
+			proclaim.throws(function () {
+				Map.prototype.delete.call('');
 			}, TypeError);
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call(1);
+			proclaim.throws(function () {
+				Map.prototype.delete.call(1);
 			}, TypeError);
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call(true);
+			proclaim.throws(function () {
+				Map.prototype.delete.call(true);
 			}, TypeError);
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call(/ /);
+			proclaim.throws(function () {
+				Map.prototype.delete.call(/ /);
 			}, TypeError);
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call(null);
+			proclaim.throws(function () {
+				Map.prototype.delete.call(null);
 			}, TypeError);
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call(undefined);
+			proclaim.throws(function () {
+				Map.prototype.delete.call(undefined);
 			}, TypeError);
 		});
 
 		it('throws a TypeError if `this` is not an a Map Object', function () {
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call([]);
+			proclaim.throws(function () {
+				Map.prototype.delete.call([]);
 			}, TypeError);
-			proclaim["throws"](function () {
-				Map.prototype['delete'].call({});
+			proclaim.throws(function () {
+				Map.prototype.delete.call({});
 			}, TypeError);
 		});
 
 		it('returns false if key was not in map', function () {
 			var map = new Map();
-			proclaim.isFalse(map['delete']('k'));
+			proclaim.isFalse(map.delete('k'));
 		});
 
 		it('returns true if key was in map', function () {
 			var map = new Map();
 			map.set('k', 1);
-			proclaim.isTrue(map['delete']('k'));
+			proclaim.isTrue(map.delete('k'));
 		});
 	});
 
@@ -407,7 +407,7 @@ describe('Map', function () {
 		proclaim.equal(o.size, 0);
 		o.set("a", "a");
 		proclaim.equal(o.size, 1);
-		o["delete"]("a"); // Use square-bracket syntax to avoid a reserved word in old browsers
+		o.delete("a");
 		proclaim.equal(o.size, 0);
 	});
 
@@ -505,13 +505,13 @@ describe('Map', function () {
 		o.set(generic, callback);
 		o.set(o, callback);
 		proclaim.equal(o.has(callback) && o.has(generic) && o.has(o), true);
-		o["delete"](callback);
-		o["delete"](generic);
-		o["delete"](o);
+		o.delete(callback);
+		o.delete(generic);
+		o.delete(o);
 		proclaim.equal(!o.has(callback) && !o.has(generic) && !o.has(o), true);
-		proclaim.ok(o["delete"](o) === false);
+		proclaim.ok(o.delete(o) === false);
 		o.set(o, callback);
-		proclaim.ok(o["delete"](o));
+		proclaim.ok(o.delete(o));
 	});
 
 	it("does not throw an error when a non-object key is used", function () {
@@ -531,7 +531,7 @@ describe('Map', function () {
 		var v = values.next();
 		proclaim.equal(k.value, "1");
 		proclaim.equal(v.value, 1);
-		o['delete']("2");
+		o.delete("2");
 		k = keys.next();
 		v = values.next();
 		proclaim.equal(k.value, "3");
@@ -622,7 +622,7 @@ describe('Map', function () {
 			proclaim.equal(key, "key " + value);
 			proclaim.equal(obj, o);
 			// even if dropped, keeps looping
-			o["delete"](key);
+			o.delete(key);
 		});
 		proclaim.equal(o.size, 0);
 	});
@@ -635,8 +635,8 @@ describe('Map', function () {
 			proclaim.equal(""+value, key);
 			// mutations work as expected
 			if (value === 1) {
-				o['delete']("0"); // remove from before current index
-				o['delete']("2"); // remove from after current index
+				o.delete("0"); // remove from before current index
+				o.delete("2"); // remove from after current index
 				o.set("3", 3); // insertion
 			} else if (value === 3) {
 				o.set("0", 0); // insertion at the end
@@ -668,7 +668,7 @@ describe('Map', function () {
 	it("does not call callback if all items are deleted", function () {
 		var x = new Map();
 		x.set(42, 'hi');
-		x["delete"](42);
+		x.delete(42);
 		var executed = false;
 		x.forEach(function () {
 			executed = true;
@@ -682,7 +682,7 @@ describe('Map', function () {
 		var x = new Map();
 		x.set(42, 'hi');
 		x.set(43, 'bye');
-		x["delete"](43);
+		x.delete(43);
 		var callCount = 0;
 		x.forEach(function () {
 			callCount = callCount + 1;
@@ -697,11 +697,11 @@ describe('Map', function () {
 		z.set(45, 'bye');
 		z.set(46, 'bye');
 		z.set(47, 'bye');
-		z["delete"](43);
-		z["delete"](44);
-		z["delete"](45);
-		z["delete"](46);
-		z["delete"](47);
+		z.delete(43);
+		z.delete(44);
+		z.delete(45);
+		z.delete(46);
+		z.delete(47);
 		callCount = 0;
 		z.forEach(function () {
 			callCount = callCount + 1;
@@ -740,7 +740,7 @@ describe('Map', function () {
 			if (i <= 0) {
 				// Remove all entries
 				map.forEach(function(val, key) {
-					map["delete"](key);
+					map.delete(key);
 				});
 			}
 			// release this frame in case timeout has occurred

--- a/polyfills/Node/prototype/contains/tests.js
+++ b/polyfills/Node/prototype/contains/tests.js
@@ -31,7 +31,7 @@ describe('on an element', function () {
 
 	// Native implementations on Safari (desktop and iOS) as of v9 return false when no argument is supplied
 	it.skip('throws when missing the argument', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			documentElement.contains();
 		});
 	});
@@ -58,7 +58,7 @@ describe('on the document', function () {
 
 	// Native implementations on Safari (desktop and iOS) as of v9 return false when no argument is supplied
 	it.skip('throws when missing the argument', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			document.contains();
 		});
 	});

--- a/polyfills/Node/prototype/isSameNode/tests.js
+++ b/polyfills/Node/prototype/isSameNode/tests.js
@@ -29,7 +29,7 @@ describe('on an element', function () {
 
 	// Native implementations on Safari (desktop and iOS) as of v9 return false when no argument is supplied
 	it.skip('throws when missing the argument', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			documentElement.isSameNode();
 		});
 	});
@@ -50,7 +50,7 @@ describe('on the document', function () {
 
 	// Native implementations on Safari (desktop and iOS) as of v9 return false when no argument is supplied
 	it.skip('throws when missing the argument', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			document.isSameNode();
 		});
 	});

--- a/polyfills/Object/assign/tests.js
+++ b/polyfills/Object/assign/tests.js
@@ -6,11 +6,11 @@ it('has the correct length', function() {
 });
 
 it('throws when target is not an object', function() {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.assign(null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.assign(undefined);
 	}, TypeError);
 });
@@ -32,15 +32,15 @@ it('Ignores null and undefined sources', function () {
 });
 
 it('throws on null or undefined targets', function() {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.assign(null, {});
 	});
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.assign(undefined, {});
 	});
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.assign(undefined, undefined);
 	});
 });
@@ -99,12 +99,12 @@ it('works as expected', function () {
 		1: 'w',
 		2: 'e'
 	});
-	proclaim["throws"](function(){
+	proclaim.throws(function(){
 		return Object.assign(null, {
 			q: 1
 		});
 	}, TypeError);
-	proclaim["throws"](function(){
+	proclaim.throws(function(){
 		return Object.assign(void 8, {
 			q: 1
 		});

--- a/polyfills/Object/entries/tests.js
+++ b/polyfills/Object/entries/tests.js
@@ -48,7 +48,7 @@ var objectKeysWorksWithPrimitives = (function() {
 
 if (supportsDescriptors) {
 	it('should terminate if getting a value throws an exception', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			var obj = {};
 			Object.defineProperty(obj, 'a', {
 				enumerable: true,
@@ -68,13 +68,13 @@ if (supportsDescriptors) {
 }
 
 it('should throw TypeError when called with `null`', function() {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Object.entries(null);
 	}, TypeError);
 });
 
 it('should throw TypeError when called with `undefined`', function() {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Object.entries(undefined);
 	}, TypeError);
 });

--- a/polyfills/Object/fromEntries/tests.js
+++ b/polyfills/Object/fromEntries/tests.js
@@ -18,23 +18,23 @@ it('is not enumerable', function () {
 });
 
 it('throws when an entry object is a primitive string', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.fromEntries(['ab']);
 	}, TypeError);
 });
 
 it('throws when an entry object is a undefined', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.fromEntries(undefined);
 	}, TypeError);
 });
 it('throws when an entry object is null', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.fromEntries(null);
 	}, TypeError);
 });
 it('throws when an entry object is absent', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.fromEntries();
 	}, TypeError);
 });

--- a/polyfills/Object/getOwnPropertyDescriptor/tests.js
+++ b/polyfills/Object/getOwnPropertyDescriptor/tests.js
@@ -40,13 +40,13 @@ it('does not throw an error for booleans', function() {
 });
 
 it('throws a TypeError for null', function() {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Object.getOwnPropertyDescriptor(null);
 	});
 });
 
 it('throws a TypeError for undefined', function() {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Object.getOwnPropertyDescriptor(undefined);
 	});
 });

--- a/polyfills/Object/getOwnPropertyDescriptors/tests.js
+++ b/polyfills/Object/getOwnPropertyDescriptors/tests.js
@@ -18,11 +18,11 @@ it('is not enumerable', function () {
 });
 
 it('throws on invalid object', function() {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.getOwnPropertyDescriptors(null);
 	}, TypeError, 'null is not an object');
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.getOwnPropertyDescriptors(undefined);
 	}, TypeError, 'undefined is not an object');
 });

--- a/polyfills/Object/getOwnPropertyNames/tests.js
+++ b/polyfills/Object/getOwnPropertyNames/tests.js
@@ -35,10 +35,10 @@ it('does not include properties inherited from a prototype', function () {
 });
 
 it('throws an error when the arg is undefined or null', function() {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.getOwnPropertyNames(undefined);
 	});
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.getOwnPropertyNames(null);
 	});
 });

--- a/polyfills/Object/keys/tests.js
+++ b/polyfills/Object/keys/tests.js
@@ -37,7 +37,7 @@ it('works as expected', function () {
 		}
 		for (i$ = 0, len$ = (ref$ = [null, void 8]).length; i$ < len$; ++i$) {
 			value = ref$[i$];
-			proclaim["throws"](fn1$, TypeError, "throws on " + value);
+			proclaim.throws(fn1$, TypeError, "throws on " + value);
 		}
 		function fn$(){
 			try {
@@ -117,13 +117,13 @@ it('works with objects containing otherwise non-enumerable keys', function () {
 });
 
 it('throws on empty, undefined, or null arguments', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.keys();
 	});
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.keys(null);
 	});
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Object.keys(undefined);
 	});
 });

--- a/polyfills/Promise/allSettled/tests.js
+++ b/polyfills/Promise/allSettled/tests.js
@@ -72,7 +72,7 @@ describe('allSettled', function () {
 	});
 
 	it("rejects with a TypeError for input that is not iterable", function () {
-		return Promise.allSettled(0)['catch'](function (err) {
+		return Promise.allSettled(0).catch(function (err) {
 			return err;
 		}).then(function (err) {
 			proclaim.ok(err instanceof TypeError);

--- a/polyfills/Promise/any/tests.js
+++ b/polyfills/Promise/any/tests.js
@@ -39,7 +39,7 @@ describe('any', function () {
 
 	it("rejects with an AggregateError when passed an array of rejected promises", function () {
 		var promises = [Promise.reject(1)];
-		return Promise.any(promises)['catch'](function (err) {
+		return Promise.any(promises).catch(function (err) {
 			return err;
 		}).then(function (err) {
 			proclaim.equal(err.name, 'AggregateError');
@@ -48,7 +48,7 @@ describe('any', function () {
 	});
 
 	it("rejects with an AggregateError when passed an empty array", function () {
-		return Promise.any([])['catch'](function (err) {
+		return Promise.any([]).catch(function (err) {
 			return err;
 		}).then(function (err) {
 			proclaim.equal(err.name, 'AggregateError');
@@ -67,7 +67,7 @@ describe('any', function () {
 	it("rejects with an AggregateError when passed an iterator containing rejected promises", function () {
 		var promises = [Promise.reject(1)];
 		var iterator = makeArrayIterator(promises);
-		return Promise.any(iterator)['catch'](function (err) {
+		return Promise.any(iterator).catch(function (err) {
 			return err;
 		}).then(function (err) {
 			proclaim.equal(err.name, 'AggregateError');
@@ -78,7 +78,7 @@ describe('any', function () {
 	it("rejects with an AggregateError when passed an empty iterable", function () {
 		var promises = [];
 		var iterator = makeArrayIterator(promises);
-		return Promise.any(iterator)['catch'](function (err) {
+		return Promise.any(iterator).catch(function (err) {
 			return err;
 		}).then(function (err) {
 			proclaim.equal(err.name, 'AggregateError');
@@ -87,7 +87,7 @@ describe('any', function () {
 	});
 
 	it("rejects with a TypeError for input that is not iterable", function () {
-		return Promise.any(0)['catch'](function (err) {
+		return Promise.any(0).catch(function (err) {
 			return err;
 		}).then(function (err) {
 			proclaim.ok(err instanceof TypeError);

--- a/polyfills/Promise/config.toml
+++ b/polyfills/Promise/config.toml
@@ -12,9 +12,7 @@ aliases = [
 dependencies = [
 	"Symbol.toStringTag",
 ]
-notes = [
-	"In IE8, the `catch` & `finally` method cannot be invoked directly since they are reserved words.  Instead, use `[\"catch\"]` and `[\"finally\"]` if intend to run your code in IE8"
-]
+notes = [ ]
 license = "MIT"
 docs = "https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise"
 repo = "https://github.com/ysmood/yaku"

--- a/polyfills/Promise/polyfill.js
+++ b/polyfills/Promise/polyfill.js
@@ -87,7 +87,7 @@
 	}
 	};
 
-	Yaku['default'] = Yaku;
+	Yaku.default = Yaku;
 
 	extend(Yaku.prototype, {
 	/**

--- a/polyfills/Promise/prototype/finally/tests.js
+++ b/polyfills/Promise/prototype/finally/tests.js
@@ -2,11 +2,11 @@
 /* globals proclaim, Promise */
 
 it('is a function', function () {
-	proclaim.isFunction(Promise.prototype['finally']);
+	proclaim.isFunction(Promise.prototype.finally);
 });
 
 it('has correct arity', function () {
-	proclaim.arity(Promise.prototype['finally'], 1);
+	proclaim.arity(Promise.prototype.finally, 1);
 });
 
 it('is not enumerable', function () {
@@ -15,36 +15,36 @@ it('is not enumerable', function () {
 
 describe('finally', function () {
 	it("does not take any arguments", function () {
-		return Promise.resolve("ok")['finally'](function (val) {
+		return Promise.resolve("ok").finally(function (val) {
 			proclaim.equal(val, undefined);
 		});
 	});
 
 	it("can throw errors and be caught", function () {
-		return Promise.resolve("ok")['finally'](function () {
+		return Promise.resolve("ok").finally(function () {
 			throw "error";
-		})['catch'](function (e) {
+		}).catch(function (e) {
 			proclaim.equal(e, 'error');
 		});
 	});
 
 	it("resolves with resolution value if finally method doesn't throw", function () {
-		return Promise.resolve("ok")['finally'](function () {
+		return Promise.resolve("ok").finally(function () {
 		}).then(function (val) {
 			proclaim.equal(val, 'ok');
 		});
 	});
 
 	it("rejects with rejection value if finally method doesn't throw", function () {
-		return Promise.reject("error")['finally'](function () {
-		})['catch'](function (val) {
+		return Promise.reject("error").finally(function () {
+		}).catch(function (val) {
 			proclaim.equal(val, 'error');
 		});
 	});
 
 	it('when resolved, only calls finally once', function () {
 		var called = 0;
-		return Promise.resolve(42)['finally'](function () {
+		return Promise.resolve(42).finally(function () {
 			called++;
 		}).then(function () {
 			proclaim.strictEqual(called, 1);
@@ -53,9 +53,9 @@ describe('finally', function () {
 
 	it('when rejected, only calls finally once', function () {
 		var called = 0;
-		return Promise.reject(42)['finally'](function () {
+		return Promise.reject(42).finally(function () {
 			called++;
-		})['catch'](function () {
+		}).catch(function () {
 			proclaim.strictEqual(called, 1);
 		});
 	});
@@ -74,7 +74,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally']()
+				}).finally()
 				.then(function onFulfilled(x) {
 					proclaim.strictEqual(x, 3);
 				}, function onRejected() {
@@ -83,10 +83,10 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function() {
-			return Promise.reject(someRejectionReason)['catch'](function(e) {
+			return Promise.reject(someRejectionReason).catch(function(e) {
 					proclaim.strictEqual(e, someRejectionReason);
 					throw e;
-				})['finally']()
+				}).finally()
 				.then(function onFulfilled() {
 					throw new Error('should not be called');
 				}, function onRejected(reason) {
@@ -101,7 +101,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					throw someRejectionReason;
 				}).then(function onFulfilled() {
@@ -112,7 +112,7 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function() {
-			return Promise.reject(anotherReason)['finally'](function onFinally() {
+			return Promise.reject(anotherReason).finally(function onFinally() {
 				proclaim.ok(arguments.length === 0);
 				throw someRejectionReason;
 			}).then(function onFulfilled() {
@@ -129,7 +129,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					return 4;
 				}).then(function onFulfilled(x) {
@@ -140,10 +140,10 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function() {
-			return Promise.reject(anotherReason)['catch'](function(e) {
+			return Promise.reject(anotherReason).catch(function(e) {
 					proclaim.strictEqual(e, anotherReason);
 					throw e;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					throw someRejectionReason;
 				}).then(function onFulfilled() {
@@ -160,7 +160,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					setTimeout(done, 0.1e3);
 					return new Promise(function() {}); // forever pending
@@ -172,10 +172,10 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function(done) {
-			Promise.reject(someRejectionReason)['catch'](function(e) {
+			Promise.reject(someRejectionReason).catch(function(e) {
 					proclaim.strictEqual(e, someRejectionReason);
 					throw e;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					setTimeout(done, 0.1e3);
 					return new Promise(function() {}); // forever pending
@@ -193,7 +193,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					return Promise.resolve(4);
 				}).then(function onFulfilled(x) {
@@ -204,10 +204,10 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function() {
-			return Promise.reject(someRejectionReason)['catch'](function(e) {
+			return Promise.reject(someRejectionReason).catch(function(e) {
 					proclaim.strictEqual(e, someRejectionReason);
 					throw e;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					return Promise.resolve(4);
 				}).then(function onFulfilled() {
@@ -224,7 +224,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					return Promise.reject(4);
 				}).then(function onFulfilled() {
@@ -236,10 +236,10 @@ describe('onFinally', function() {
 
 		specify('from rejected', function() {
 			var newReason = {};
-			return Promise.reject(someRejectionReason)['catch'](function(e) {
+			return Promise.reject(someRejectionReason).catch(function(e) {
 					proclaim.strictEqual(e, someRejectionReason);
 					throw e;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					return Promise.reject(newReason);
 				}).then(function onFulfilled() {
@@ -256,7 +256,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					setTimeout(done, 1.5e3);
 					return new Promise(function(resolve) {
@@ -270,10 +270,10 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function(done) {
-			Promise.reject(3)['catch'](function(e) {
+			Promise.reject(3).catch(function(e) {
 					proclaim.strictEqual(e, 3);
 					throw e;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					setTimeout(done, 1.5e3);
 					return new Promise(function(resolve) {
@@ -293,7 +293,7 @@ describe('onFinally', function() {
 				.then(function(x) {
 					proclaim.strictEqual(x, 3);
 					return x;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					setTimeout(done, 1.5e3);
 					return new Promise(function(resolve, reject) {
@@ -307,10 +307,10 @@ describe('onFinally', function() {
 		});
 
 		specify('from rejected', function(done) {
-			Promise.reject(someRejectionReason)['catch'](function(e) {
+			Promise.reject(someRejectionReason).catch(function(e) {
 					proclaim.strictEqual(e, someRejectionReason);
 					throw e;
-				})['finally'](function onFinally() {
+				}).finally(function onFinally() {
 					proclaim.ok(arguments.length === 0);
 					setTimeout(done, 1.5e3);
 					return new Promise(function(resolve, reject) {

--- a/polyfills/Promise/tests.js
+++ b/polyfills/Promise/tests.js
@@ -227,7 +227,7 @@ it('should resolve Promise.all when all promises resolve', function(done) {
 	]).then(function(results) {
 		proclaim.deepEqual(results, [3,5]);
 		done();
-	})['catch'](function(e) {
+	}).catch(function(e) {
 		done(e);
 	});
 });

--- a/polyfills/Reflect/apply/tests.js
+++ b/polyfills/Reflect/apply/tests.js
@@ -18,45 +18,45 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if `target` is not callable', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply('');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply(9);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply({});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply([]);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply(/./);
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.apply(Symbol());
 		}, TypeError);
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.apply(Symbol('a'));
 		}, TypeError);
 	}
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply(true);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply(Number(9));
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply(new Number(9));
 	}, TypeError);
 });
@@ -81,7 +81,7 @@ it('spreads third argument as the `arguments` for the `target` function', functi
 });
 
 it('throws a TypeError if third argument is not ArrayLike', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.apply(function () {}, 1, 1);
 	}, TypeError);
 });

--- a/polyfills/Reflect/construct/tests.js
+++ b/polyfills/Reflect/construct/tests.js
@@ -18,27 +18,27 @@ it('is not enumerable', function () {
 });
 
 it('throws TypeError if `newTarget` is not a constuctor', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, [], 1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, [], null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, [], {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, [], Math.sin);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, [], 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, [], /./);
 	}, TypeError);
 });
@@ -55,27 +55,27 @@ it('if `newTarget` is absent, let `newTarget` be `target`', function () {
 });
 
 it('throws TypeError is `target` is not a constructor', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(1, []);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(null, []);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct({}, []);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(Math.sin, []);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct('a', []);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(/./, []);
 	}, TypeError);
 });
@@ -87,7 +87,7 @@ it('spreads `argumentsList` as the arguments for the `target` constructor', func
 });
 
 it('throws TypeError is `argumentsList` is not ArrayLike', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.construct(function () {}, 9);
 	}, TypeError);
 });

--- a/polyfills/Reflect/defineProperty/tests.js
+++ b/polyfills/Reflect/defineProperty/tests.js
@@ -39,24 +39,24 @@ if ('freeze' in Object && (function () {
 }
 
 it('throws a TypeError if target is not an Object.', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.defineProperty(1, 'a', {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.defineProperty(null, 'a', {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.defineProperty(undefined, 'a', {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.defineProperty('', 'a', {});
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			Reflect.defineProperty(Symbol(), 'a', {});
 		}, TypeError);
 	}

--- a/polyfills/Reflect/deleteProperty/tests.js
+++ b/polyfills/Reflect/deleteProperty/tests.js
@@ -62,24 +62,24 @@ if ('freeze' in Object && (function () {
 }
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.deleteProperty(1, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.deleteProperty(null, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.deleteProperty(undefined, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.deleteProperty('', 'a');
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.deleteProperty(Symbol(), 'a');
 		}, TypeError);
 	}

--- a/polyfills/Reflect/get/tests.js
+++ b/polyfills/Reflect/get/tests.js
@@ -18,24 +18,24 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.get(1, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.get(null, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.get(undefined, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.get('', 'a');
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.get(Symbol(), 'a');
 		}, TypeError);
 	}

--- a/polyfills/Reflect/getOwnPropertyDescriptor/tests.js
+++ b/polyfills/Reflect/getOwnPropertyDescriptor/tests.js
@@ -18,24 +18,24 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if target is not an Object',function(){
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Reflect.getOwnPropertyDescriptor(1, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Reflect.getOwnPropertyDescriptor(null, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Reflect.getOwnPropertyDescriptor(undefined, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		Reflect.getOwnPropertyDescriptor('', 'a');
 	}, TypeError);
 
 	if('Symbol' in self) {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			Reflect.getOwnPropertyDescriptor(Symbol(), 'a');
 		}, TypeError);
 	}

--- a/polyfills/Reflect/getPrototypeOf/tests.js
+++ b/polyfills/Reflect/getPrototypeOf/tests.js
@@ -30,24 +30,24 @@ it('returns the internal [[Prototype]] of an object', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.getPrototypeOf(1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.getPrototypeOf(null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.getPrototypeOf(undefined);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.getPrototypeOf('');
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.getPrototypeOf(Symbol());
 		}, TypeError);
 	}

--- a/polyfills/Reflect/has/tests.js
+++ b/polyfills/Reflect/has/tests.js
@@ -35,24 +35,24 @@ it('returns false if the property is not anywhere in the prototype chain', funct
 });
 
 it('throws a TypeError if `target` is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.has(1, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.has(null, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.has(undefined, 'a');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.has('', 'a');
 	}, TypeError);
 
 	if('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.has(Symbol(), 'a');
 		}, TypeError);
 	}

--- a/polyfills/Reflect/isExtensible/tests.js
+++ b/polyfills/Reflect/isExtensible/tests.js
@@ -43,24 +43,24 @@ if ('preventExtensions' in Object && (function () {
 }
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible(1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible(null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible(undefined);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible('');
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.isExtensible(Symbol());
 		}, TypeError);
 	}

--- a/polyfills/Reflect/ownKeys/tests.js
+++ b/polyfills/Reflect/ownKeys/tests.js
@@ -27,24 +27,24 @@ it('returns an empty array if target has no own properties', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.ownKeys(1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.ownKeys(null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.ownKeys(undefined);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.ownKeys('');
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.ownKeys(Symbol());
 		}, TypeError);
 	}

--- a/polyfills/Reflect/preventExtensions/tests.js
+++ b/polyfills/Reflect/preventExtensions/tests.js
@@ -49,24 +49,24 @@ if ('isExtensible' in Object && 'preventExtensions' in Object && (function () {
 }
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible(1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible(null);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible(undefined);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.isExtensible('');
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.isExtensible(Symbol());
 		}, TypeError);
 	}

--- a/polyfills/Reflect/set/tests.js
+++ b/polyfills/Reflect/set/tests.js
@@ -18,24 +18,24 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.set(1, 'a', 1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.set(null, 'a', 1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.set(undefined, 'a', 1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.set('', 'a', 1);
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.set(Symbol(), 'p', 42);
 		}, TypeError);
 	}

--- a/polyfills/Reflect/setPrototypeOf/tests.js
+++ b/polyfills/Reflect/setPrototypeOf/tests.js
@@ -18,19 +18,19 @@ it('is not enumerable', function () {
 });
 
 it('throws a TypeError if proto is not Object or proto is not null', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf({}, undefined);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf({}, 1);
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf({}, 'string');
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf({}, true);
 	}, TypeError);
 });
@@ -54,24 +54,24 @@ if ('__proto__' in Object.prototype) {
 	});
 }
 it('throws a TypeError if target is not an Object', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf(1, {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf(null, {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf(undefined, {});
 	}, TypeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		Reflect.setPrototypeOf('', {});
 	}, TypeError);
 
 	if ('Symbol' in self) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			Reflect.setPrototypeOf(Symbol(), {});
 		}, TypeError);
 	}

--- a/polyfills/Reflect/tests.js
+++ b/polyfills/Reflect/tests.js
@@ -16,11 +16,11 @@ if ('getPrototypeOf' in Object) {
 }
 
 it('cannot be called or constructed', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		// eslint-disable-next-line no-obj-calls
 		Reflect();
 	});
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		// eslint-disable-next-line no-obj-calls
 		new Reflect;
 	});

--- a/polyfills/RegExp/prototype/flags/tests.js
+++ b/polyfills/RegExp/prototype/flags/tests.js
@@ -55,7 +55,7 @@ if (supportsDescriptors) {
 	ifCallAllowsPrimitivesIt('throws when not called on an object', function () {
 		var nonObjects = ['', false, true, 42, NaN, null, undefined];
 		nonObjects.forEach(function (nonObject) {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				testGenericRegExpFlags(nonObject);
 			}, TypeError);
 		});

--- a/polyfills/ResizeObserver/tests.js
+++ b/polyfills/ResizeObserver/tests.js
@@ -45,7 +45,7 @@ describe("ResizeObserver", function () {
 		var fn = function() {
 			new ResizeObserver()
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to construct 'ResizeObserver': 1 argument required, but only 0 present."
 		)
@@ -55,7 +55,7 @@ describe("ResizeObserver", function () {
 		var fn = function() {
 			new ResizeObserver(1)
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to construct 'ResizeObserver': The callback provided as parameter 1 is not a function."
 		)
@@ -66,7 +66,7 @@ describe("ResizeObserver", function () {
 			ro = new ResizeObserver(function() {})
 			ro.observe()
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to execute 'observe' on 'ResizeObserver': 1 argument required, but only 0 present."
 		)
@@ -77,7 +77,7 @@ describe("ResizeObserver", function () {
 			ro = new ResizeObserver(function() {})
 			ro.observe(1)
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element"
 		)
@@ -88,7 +88,7 @@ describe("ResizeObserver", function () {
 			ro = new ResizeObserver(function() {})
 			ro.observe(null)
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element"
 		)
@@ -99,7 +99,7 @@ describe("ResizeObserver", function () {
 			ro = new ResizeObserver(function() {})
 			ro.unobserve()
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to execute 'unobserve' on 'ResizeObserver': 1 argument required, but only 0 present."
 		)
@@ -110,7 +110,7 @@ describe("ResizeObserver", function () {
 			ro = new ResizeObserver(function() {})
 			ro.unobserve(1)
 		}
-		proclaim["throws"](
+		proclaim.throws(
 			fn,
 			"Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element"
 		)

--- a/polyfills/Set/config.toml
+++ b/polyfills/Set/config.toml
@@ -17,7 +17,6 @@ dependencies = [
 	"Symbol.species",
 ]
 notes = [
-	"For compatibility with very old engines, `Set.prototype.delete` must be accessed using square bracket notation because 'delete' is a reserved word. `mySet.delete()` is an error in IE8. Use `mySet['delete']()` instead.",
 	"The test suite for this polyfill is derived from work of Andrea Giammarchi which is [published under an MIT licence](https://github.com/WebReflection/es6-collections)"
 ]
 

--- a/polyfills/Set/tests.js
+++ b/polyfills/Set/tests.js
@@ -48,7 +48,7 @@ describe('Set', function() {
 			proclaim.equal(o.size, 0);
 			o.add("a");
 			proclaim.equal(o.size, 1);
-			o["delete"]("a"); // Use square-bracket syntax to avoid a reserved word in old browsers
+			o.delete("a");
 			proclaim.equal(o.size, 0);
 		});
 
@@ -76,15 +76,15 @@ describe('Set', function() {
 			proclaim.equal(o.has(callback), true);
 			proclaim.equal(o.has(generic), true);
 			proclaim.equal(o.has(o), true);
-			o["delete"](callback);
-			o["delete"](generic);
-			o["delete"](o);
+			o.delete(callback);
+			o.delete(generic);
+			o.delete(o);
 			proclaim.equal(o.has(callback), false);
 			proclaim.equal(o.has(generic), false);
 			proclaim.equal(o.has(o), false);
-			proclaim.equal(o["delete"](o), false);
+			proclaim.equal(o.delete(o), false);
 			o.add(o);
-			proclaim.equal(o["delete"](o), true);
+			proclaim.equal(o.delete(o), true);
 		});
 
 		it("exhibits correct iterator behaviour", function () {
@@ -94,7 +94,7 @@ describe('Set', function() {
 			var values = o.values();
 			var v = values.next();
 			proclaim.equal(v.value, "1");
-			o['delete']("2");
+			o.delete("2");
 			v = values.next();
 			proclaim.equal(v.value, "3");
 			// insertion of previously-removed item goes to the end
@@ -179,7 +179,7 @@ describe('Set', function() {
 				proclaim.equal(value, sameValue);
 				proclaim.equal(obj, o);
 				// even if dropped, keeps looping
-				o["delete"](value);
+				o.delete(value);
 			});
 			proclaim.equal(o.size, 0);
 		});
@@ -189,7 +189,7 @@ describe('Set', function() {
 
 			// Iterator is correct when first item is deleted
 			o = new Set([1, 2, 3]);
-			o["delete"](1);
+			o.delete(1);
 			entries = o.entries();
 			current = entries.next();
 			proclaim.equal(false, current.done);
@@ -203,7 +203,7 @@ describe('Set', function() {
 
 			// Iterator is correct when middle item is deleted
 			o = new Set([1, 2, 3]);
-			o["delete"](2);
+			o.delete(2);
 			entries = o.entries();
 			current = entries.next();
 			proclaim.equal(false, current.done);
@@ -217,7 +217,7 @@ describe('Set', function() {
 
 			// Iterator is correct when last item is deleted
 			o = new Set([1, 2, 3]);
-			o["delete"](3);
+			o.delete(3);
 			entries = o.entries();
 			current = entries.next();
 			proclaim.equal(false, current.done);
@@ -238,8 +238,8 @@ describe('Set', function() {
 				proclaim.equal(value, valueAgain);
 				// mutations work as expected
 				if (value === "1") {
-					o['delete']("0"); // remove from before current index
-					o['delete']("2"); // remove from after current index
+					o.delete("0"); // remove from before current index
+					o.delete("2"); // remove from after current index
 					o.add("3"); // insertion
 				} else if (value === "3") {
 					o.add("0"); // insertion at the end
@@ -258,7 +258,7 @@ describe('Set', function() {
 		});
 
 		it("throws for non-iterable arguments", function() {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				new Set(1);
 			}, TypeError);
 		});

--- a/polyfills/String/fromCodePoint/tests.js
+++ b/polyfills/String/fromCodePoint/tests.js
@@ -30,43 +30,43 @@ it('works as expected', function () {
 	proclaim.strictEqual(String.fromCodePoint(0x61, 0x62, 0x1D307), 'ab\uD834\uDF07');
 	proclaim.strictEqual(String.fromCodePoint(false), '\0');
 	proclaim.strictEqual(String.fromCodePoint(null), '\0');
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint('_');
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint('+Infinity');
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint('-Infinity');
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(-1);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(0x10FFFF + 1);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(3.14);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(3e-2);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(-Infinity);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(Infinity);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(NaN);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(undefined);
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint({});
 	}, RangeError);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.fromCodePoint(/./);
 	}, RangeError);
 	var tmp = 0x60;

--- a/polyfills/String/prototype/codePointAt/tests.js
+++ b/polyfills/String/prototype/codePointAt/tests.js
@@ -49,19 +49,19 @@ describe('#codePointAt()', function () {
 	});
 
 	ifHasStrictModeIt('should throw a TypeError when called on null or undefined', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.codePointAt.call(undefined);
 		}, TypeError);
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.codePointAt.call(null);
 		}, TypeError);
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.codePointAt.apply(undefined);
 		}, TypeError);
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.codePointAt.apply(null);
 		}, TypeError);
 	});
@@ -141,10 +141,10 @@ it('works as expected', function () {
 	proclaim.strictEqual('\uDF06abc'.codePointAt(null), 0xDF06);
 	proclaim.strictEqual('\uDF06abc'.codePointAt(undefined), 0xDF06);
 	if (hasStrictMode) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.codePointAt.call(null, 0);
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.codePointAt.call(undefined, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/endsWith/tests.js
+++ b/polyfills/String/prototype/endsWith/tests.js
@@ -46,15 +46,15 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.endsWith.call(null, '.');
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.endsWith.call(undefined, '.');
 		}, TypeError);
 	}
 	re = /./;
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		'/./'.endsWith(re);
 	}, TypeError);
 	if ('Symbol' in window && 'match' in Symbol) {
@@ -65,7 +65,7 @@ it('works as expected', function () {
 	proclaim.isTrue('[object Object]'.endsWith(O));
 	if ('Symbol' in window && 'match' in Symbol) {
 		O[typeof Symbol != 'undefined' && Symbol !== null ? Symbol.match : undefined] = true;
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			'[object Object]'.endsWith(O);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/includes/tests.js
+++ b/polyfills/String/prototype/includes/tests.js
@@ -30,15 +30,15 @@ it('works as expected', function(){
 		}).call(undefined);
 
 		if (supportsStrictModeTests) {
-			proclaim["throws"](function(){
+			proclaim.throws(function(){
 				String.prototype.includes.call(null, '.');
 			}, TypeError);
-			proclaim["throws"](function(){
+			proclaim.throws(function(){
 				String.prototype.includes.call(undefined, '.');
 			}, TypeError);
 		}
 		re = /./;
-		proclaim["throws"](function(){
+		proclaim.throws(function(){
 			'/./'.includes(re);
 		}, TypeError);
 	if ('Symbol' in window && 'match' in Symbol) {
@@ -49,7 +49,7 @@ it('works as expected', function(){
 		proclaim.isTrue('[object Object]'.includes(O));
 	if ('Symbol' in window && 'match' in Symbol) {
 		O[typeof Symbol != 'undefined' && Symbol !== null ? Symbol.match : undefined] = true;
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			'[object Object]'.includes(O);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/matchAll/tests.js
+++ b/polyfills/String/prototype/matchAll/tests.js
@@ -35,11 +35,11 @@ describe('String.prototype.matchAll', function () {
 
 	if (supportsStrictModeTests) {
 		it('throws incoercible objects', function () {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				String.prototype.matchAll.call(undefined);
 			}, TypeError);
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				String.prototype.matchAll.call(null);
 			}, TypeError);
 		});
@@ -81,7 +81,7 @@ describe('String.prototype.matchAll', function () {
 	});
 
 	it("throws for a non-global regex", function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			'a'.matchAll(/a/)
 		}, TypeError);
 	});

--- a/polyfills/String/prototype/normalize/tests.js
+++ b/polyfills/String/prototype/normalize/tests.js
@@ -18,15 +18,15 @@ it('is not enumerable', function () {
 });
 
 it('throws a RangeError if ToString(form) value is not a valid form name', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		'a'.normalize('b');
 	}, RangeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		'a'.normalize('NFC1');
 	}, RangeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		'a'.normalize(null);
 	}, RangeError);
 });
@@ -82,13 +82,13 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('throws TypeError if `this` is null', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.normalize.call(null);
 		}, TypeError);
 	});
 
 	it('throws TypeError if `this` is undefined', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.normalize.call(undefined);
 		}, TypeError);
 	});

--- a/polyfills/String/prototype/padEnd/tests.js
+++ b/polyfills/String/prototype/padEnd/tests.js
@@ -40,10 +40,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.padEnd.call(null, 0);
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.padEnd.call(undefined, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/padStart/tests.js
+++ b/polyfills/String/prototype/padStart/tests.js
@@ -39,10 +39,10 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function(){
+		proclaim.throws(function(){
 			String.prototype.padStart.call(null, 0);
 		}, TypeError);
-		proclaim["throws"](function(){
+		proclaim.throws(function(){
 			String.prototype.padStart.call(undefined, 0);
 		}, TypeError);
 	}

--- a/polyfills/String/prototype/repeat/tests.js
+++ b/polyfills/String/prototype/repeat/tests.js
@@ -35,15 +35,15 @@ it('works with strings', function () {
 });
 
 it('throws invalid counts', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		'abc'.repeat(-Infinity);
 	}, RangeError);
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		'abc'.repeat(-1);
 	}, RangeError);
 
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		'abc'.repeat(+Infinity);
 	}, RangeError);
 });
@@ -74,35 +74,35 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('throws incoercible objects', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.call(undefined);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.call(undefined, 4);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.call(null);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.call(null, 4);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.apply(undefined);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.apply(undefined, [4]);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.apply(null);
 		});
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.repeat.apply(null, [4]);
 		});
 	});

--- a/polyfills/String/prototype/replaceAll/tests.js
+++ b/polyfills/String/prototype/replaceAll/tests.js
@@ -26,11 +26,11 @@ describe('String.prototype.replaceAll', function () {
 
 	if (supportsStrictModeTests) {
 		it('throws incoercible objects', function () {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				String.prototype.replaceAll.call(undefined);
 			}, TypeError);
 
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				String.prototype.replaceAll.call(null);
 			}, TypeError);
 		});
@@ -55,7 +55,7 @@ describe('String.prototype.replaceAll', function () {
 	});
 
 	it("throws a TypeError if searchValue is a regex without a global flag", function() {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			'origami.origami.origami'.replaceAll(/\./, 'fox');
 		}, TypeError);
 	});

--- a/polyfills/String/prototype/startsWith/tests.js
+++ b/polyfills/String/prototype/startsWith/tests.js
@@ -37,14 +37,14 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.startsWith.call(null, '.');
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.startsWith.call(undefined, '.');
 		}, TypeError);
 	}
-	proclaim["throws"](function(){
+	proclaim.throws(function(){
 		'/./'.startsWith(/./);
 	}, TypeError);
 	proclaim.isTrue('[object Object]'.startsWith({}));

--- a/polyfills/String/prototype/trim/tests.js
+++ b/polyfills/String/prototype/trim/tests.js
@@ -35,12 +35,12 @@ var supportsStrictModeTests = (function () {
 
 if (supportsStrictModeTests) {
 	it('should throw TypeError if called with a null context', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.trim.call(null, 0);
 		}, TypeError);
 	});
 	it('should throw TypeError if called with an undefined context', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.prototype.trim.call(undefined, 0);
 		}, TypeError);
 	});

--- a/polyfills/String/prototype/trimEnd/tests.js
+++ b/polyfills/String/prototype/trimEnd/tests.js
@@ -28,11 +28,11 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 	"use strict";
 			String.prototype.trimEnd.call(null, 0);
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 	"use strict";
 			String.prototype.trimEnd.call(void 0, 0);
 		}, TypeError);

--- a/polyfills/String/prototype/trimStart/tests.js
+++ b/polyfills/String/prototype/trimStart/tests.js
@@ -28,11 +28,11 @@ it('works as expected', function () {
 	}).call(undefined);
 
 	if (supportsStrictModeTests) {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 	"use strict";
 			String.prototype.trimStart.call(null, 0);
 		}, TypeError);
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 	"use strict";
 			String.prototype.trimStart.call(void 0, 0);
 		}, TypeError);

--- a/polyfills/String/raw/tests.js
+++ b/polyfills/String/raw/tests.js
@@ -19,7 +19,7 @@ it('is not enumerable', function () {
 
 if ('Symbol' in self) {
 	it('throws a TypeError if nextKey is a Symbol', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.raw({
 				raw: {
 					length: 1,
@@ -32,7 +32,7 @@ if ('Symbol' in self) {
 
 if ('Symbol' in self) {
 	it('throws a TypeError if length is a Symbol', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.raw({
 				raw: {
 					length: Symbol()
@@ -43,7 +43,7 @@ if ('Symbol' in self) {
 }
 
 it('calls the toString method on the keys', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.raw({
 			raw: {
 				length: 1,
@@ -59,13 +59,13 @@ it('calls the toString method on the keys', function () {
 
 if ('Symbol' in self) {
 	it('throws a TypeError if a Symbol is used as a substitution', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.raw({
 				raw: ['a', 'b', 'c']
 			}, '', Symbol(''));
 		}, TypeError);
 
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			String.raw({
 				raw: ['a', 'b', 'c']
 			}, Symbol(''), '');
@@ -149,19 +149,19 @@ it('returns empty string if template.raw.length is less than 1.', function () {
 });
 
 it('throws a TypeError if called with null', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.raw(null);
 	});
 });
 
 it('throws a TypeError if called with undefined', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.raw(undefined);
 	});
 });
 
 it('throws a TypeError if called with raw as null', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.raw({
 			raw: null
 		});
@@ -169,7 +169,7 @@ it('throws a TypeError if called with raw as null', function () {
 });
 
 it('throws a TypeError if called with raw as undefined', function () {
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		String.raw({
 			raw: undefined
 		});

--- a/polyfills/Symbol/prototype/description/tests.js
+++ b/polyfills/Symbol/prototype/description/tests.js
@@ -81,55 +81,55 @@ if (Object.getOwnPropertyDescriptor) {
 	});
 
 	it('throws an error if context is a number', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call(1);
 		}, TypeError);
 	});
 
 	it('throws an error if context is null', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call(null);
 		}, TypeError);
 	});
 
 	it('throws an error if context is undefined', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call(undefined);
 		}, TypeError);
 	});
 
 	it('throws an error if context is an array', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call([]);
 		}, TypeError);
 	});
 
 	it('throws an error if context is an object', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call({});
 		}, TypeError);
 	});
 
 	it('throws an error if context is a regex', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call(/./);
 		}, TypeError);
 	});
 
 	it('throws an error if context is NaN', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call(NaN);
 		}, TypeError);
 	});
 
 	it('throws an error if context is a function', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call(function(){});
 		}, TypeError);
 	});
 
 	it('throws an error if context is a string', function () {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			getter.call('kate');
 		}, TypeError);
 	});

--- a/polyfills/Symbol/tests.js
+++ b/polyfills/Symbol/tests.js
@@ -32,7 +32,7 @@ it('should throw if being used via `new`', function() {
 		// eslint-disable-next-line no-new-symbol
 		return new Symbol();
 	};
-	proclaim["throws"](test);
+	proclaim.throws(test);
 });
 
 it('should have Symbol as the constructor property', function() {
@@ -83,7 +83,7 @@ it('should create unique symbols', function() {
 });
 
 it('has for, and keyFor static methods', function() {
-	proclaim.isInstanceOf(Symbol["for"], Function);
+	proclaim.isInstanceOf(Symbol.for, Function);
 	proclaim.isInstanceOf(Symbol.keyFor, Function);
 });
 
@@ -110,12 +110,12 @@ it('Symbol.keyFor should throw if not given a symbol', function() {
 		return Symbol.keyFor(Symbol("4"));
 	};
 
-	proclaim["throws"](stringKeyFor);
-	proclaim["throws"](numberKeyFor);
-	proclaim["throws"](arrayKeyFor);
-	proclaim["throws"](objectKeyFor);
-	proclaim["throws"](boolKeyFor);
-	proclaim["throws"](undefinedKeyFor);
+	proclaim.throws(stringKeyFor);
+	proclaim.throws(numberKeyFor);
+	proclaim.throws(arrayKeyFor);
+	proclaim.throws(objectKeyFor);
+	proclaim.throws(boolKeyFor);
+	proclaim.throws(undefinedKeyFor);
 	proclaim.doesNotThrow(symbolKeyFor);
 });
 
@@ -130,18 +130,18 @@ xit('Symbol() should not add the symbol to the global registry', function() {
 
 it('Symbol["for"] should create new symbol if can not find symbol in global registry', function() {
 	var sym1 = Symbol("7");
-	var sym2 = Symbol["for"]("7");
+	var sym2 = Symbol.for("7");
 	proclaim.notEqual(sym1, sym2);
 });
 
 it('Symbol["for"] should return symbol if can find symbol in global registry', function() {
-	var sym = Symbol["for"]("8");
-	proclaim.equal(sym, Symbol["for"]("8"));
+	var sym = Symbol.for("8");
+	proclaim.equal(sym, Symbol.for("8"));
 });
 
 it('Symbol.keyFor should return key of symbol if can find symbol in global registry', function() {
 	var key = "9";
-	var sym = Symbol["for"](key);
+	var sym = Symbol.for(key);
 	proclaim.equal(Symbol.keyFor(sym), key);
 });
 
@@ -208,7 +208,7 @@ xit('should not allow implicit string coercion', function() {
 	var implicitStringCoercion = function() {
 		return Symbol('10') + '';
 	};
-	proclaim["throws"](implicitStringCoercion);
+	proclaim.throws(implicitStringCoercion);
 });
 
 it('should create Object without symbols', function () {
@@ -314,55 +314,55 @@ describe('Polyfill.prototype.description', function () {
 		});
 
 		it('throws an error if context is a number', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call(1);
 			}, TypeError);
 		});
 
 		it('throws an error if context is null', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call(null);
 			}, TypeError);
 		});
 
 		it('throws an error if context is undefined', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call(undefined);
 			}, TypeError);
 		});
 
 		it('throws an error if context is an array', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call([]);
 			}, TypeError);
 		});
 
 		it('throws an error if context is an object', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call({});
 			}, TypeError);
 		});
 
 		it('throws an error if context is a regex', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call(/./);
 			}, TypeError);
 		});
 
 		it('throws an error if context is NaN', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call(NaN);
 			}, TypeError);
 		});
 
 		it('throws an error if context is a function', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call(function(){});
 			}, TypeError);
 		});
 
 		it('throws an error if context is a string', function () {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				getter.call('kate');
 			}, TypeError);
 		});

--- a/polyfills/URL/polyfill.js
+++ b/polyfills/URL/polyfill.js
@@ -274,7 +274,7 @@
 
 					keys.sort();
 					for (var i = 0; i < keys.length; i++) {
-						this["delete"](keys[i]);
+						this.delete(keys[i]);
 					}
 					for (var j = 0; j < keys.length; j++) {
 						key = keys[j];

--- a/polyfills/URL/tests.js
+++ b/polyfills/URL/tests.js
@@ -126,12 +126,12 @@ it('Parameter Mutation', function () {
 	proclaim.equal(url.search, '?a=1&b=2&a=3');
 	proclaim.equal(url.href, 'http://example.com/?a=1&b=2&a=3');
 
-	url.searchParams['delete']('a');
+	url.searchParams.delete('a');
 	proclaim.equal(url.search, '?b=2');
 	proclaim.deepEqual(url.searchParams.getAll('a'), []);
 	proclaim.equal(url.href, 'http://example.com/?b=2');
 
-	url.searchParams['delete']('b');
+	url.searchParams.delete('b');
 	proclaim.deepEqual(url.searchParams.getAll('b'), []);
 	proclaim.equal(url.href, 'http://example.com/');
 
@@ -239,11 +239,11 @@ it('URLSearchParams mutation', function () {
 	proclaim.deepEqual(p.getAll('a'), ['1', '3']);
 	proclaim.equal(String(p), 'a=1&b=2&a=3');
 
-	p['delete']('a');
+	p.delete('a');
 	proclaim.equal(String(p), 'b=2');
 	proclaim.deepEqual(p.getAll('a'), []);
 
-	p['delete']('b');
+	p.delete('b');
 	proclaim.deepEqual(p.getAll('b'), []);
 
 	p = new URLSearchParams('m=9&n=3');
@@ -414,7 +414,7 @@ describe('WPT tests', function () {
 	it.skip('throws with DOMException as argument', function() {
 		var params = new URLSearchParams(DOMException);
 		proclaim.equal(params.toString(), "INDEX_SIZE_ERR=1&DOMSTRING_SIZE_ERR=2&HIERARCHY_REQUEST_ERR=3&WRONG_DOCUMENT_ERR=4&INVALID_CHARACTER_ERR=5&NO_DATA_ALLOWED_ERR=6&NO_MODIFICATION_ALLOWED_ERR=7&NOT_FOUND_ERR=8&NOT_SUPPORTED_ERR=9&INUSE_ATTRIBUTE_ERR=10&INVALID_STATE_ERR=11&SYNTAX_ERR=12&INVALID_MODIFICATION_ERR=13&NAMESPACE_ERR=14&INVALID_ACCESS_ERR=15&VALIDATION_ERR=16&TYPE_MISMATCH_ERR=17&SECURITY_ERR=18&NETWORK_ERR=19&ABORT_ERR=20&URL_MISMATCH_ERR=21&QUOTA_EXCEEDED_ERR=22&TIMEOUT_ERR=23&INVALID_NODE_TYPE_ERR=24&DATA_CLONE_ERR=25")
-		proclaim["throws"](function() { new URLSearchParams(DOMException.prototype) },
+		proclaim.throws(function() { new URLSearchParams(DOMException.prototype) },
 			"Constructing a URLSearchParams from DOMException.prototype should throw due to branding checks"
 		);
 	})
@@ -590,8 +590,8 @@ describe('WPT tests', function () {
 		proclaim.equal(params.get("a"), "b");
 		proclaim.equal(params.get("c"), "d");
 
-		proclaim["throws"](function() { new URLSearchParams([[1]]); });
-		proclaim["throws"](function() { new URLSearchParams([[1,2,3]]); });
+		proclaim.throws(function() { new URLSearchParams([[1]]); });
+		proclaim.throws(function() { new URLSearchParams([[1,2,3]]); });
 	});
 
 	[

--- a/polyfills/UserTiming/tests.js
+++ b/polyfills/UserTiming/tests.js
@@ -20,7 +20,7 @@ describe("mark()", function() {
 	});
 
 	it("should throw an exception when a null argument is given", function() {
-		proclaim["throws"](perf.mark);
+		proclaim.throws(perf.mark);
 	});
 
 	it("should throw an exception when passing in a NavigationTiming mark", function() {
@@ -29,7 +29,7 @@ describe("mark()", function() {
 			typeof window.performance !== "undefined" &&
 			typeof window.performance.timing !== "undefined" &&
 			window.performance.timing.navigationStart) {
-			proclaim["throws"](function() {
+			proclaim.throws(function() {
 				perf.mark("navigationStart");
 			});
 		}
@@ -287,22 +287,22 @@ describe("measure()", function() {
 	});
 
 	it("should throw an error if not given a name", function() {
-		proclaim["throws"](perf.measure);
+		proclaim.throws(perf.measure);
 	});
 
 	it("should throw an error if not given a name", function() {
-		proclaim["throws"](perf.measure);
+		proclaim.throws(perf.measure);
 	});
 
 	it("should throw an exception if the start mark name is not found", function() {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			perf.measure("foo", "BAD_MARK!");
 		});
 	});
 
 	it("should throw an exception if the end mark name is not found", function() {
 		perf.mark("1");
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			perf.measure("foo", "1", "BAD_MARK!");
 		});
 	});

--- a/polyfills/WeakMap/detect.js
+++ b/polyfills/WeakMap/detect.js
@@ -3,7 +3,7 @@
 		if ("WeakMap" in self && self.WeakMap.length === 0) {
 			var o = {};
 			var wm = new self.WeakMap([[o, 'test']]);
-			return (wm.get(o) === 'test' && wm["delete"](0) === false);
+			return (wm.get(o) === 'test' && wm.delete(0) === false);
 		} else {
 			return false;
 		}

--- a/polyfills/WeakMap/tests.js
+++ b/polyfills/WeakMap/tests.js
@@ -27,7 +27,7 @@ it("has valid constructor", function () {
 		proclaim.equal((new WeakMap).__proto__ === WeakMap.prototype, true);
 	}
 
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		WeakMap();
 	}, TypeError);
 });
@@ -35,7 +35,7 @@ it("has valid constructor", function () {
 it('has get, set, delete, and has functions', function() {
 	proclaim.isFunction(WeakMap.prototype.get);
 	proclaim.isFunction(WeakMap.prototype.set);
-	proclaim.isFunction(WeakMap.prototype['delete']);
+	proclaim.isFunction(WeakMap.prototype.delete);
 	proclaim.isFunction(WeakMap.prototype.has);
 });
 it('should perform as expected', function() {
@@ -60,8 +60,8 @@ it('should perform as expected', function() {
 	proclaim.equal(wm.has({}), false);
 
 	// Ensure that delete returns true/false indicating if the value was removed
-	proclaim.equal(wm['delete'](o1), true);
-	proclaim.equal(wm['delete']({}), false);
+	proclaim.equal(wm.delete(o1), true);
+	proclaim.equal(wm.delete({}), false);
 
 	proclaim.equal(wm.get(o1), undefined);
 	proclaim.equal(wm.has(o1), false);
@@ -96,7 +96,7 @@ if ('freeze' in Object) {
 		map.set(f, 42);
 		proclaim.isTrue(map.has(f));
 		proclaim.strictEqual(map.get(f), 42);
-		map['delete'](f);
+		map.delete(f);
 	proclaim.isFalse(map.has(f));
 	proclaim.isUndefined(map.get(f));
 	});
@@ -116,8 +116,8 @@ if ('Symbol' in window && 'iterator' in Symbol && typeof [][Symbol.iterator] ===
 }
 
 it('WeakMap.prototype.delete', function () {
-	proclaim.isFunction(WeakMap.prototype['delete']);
-	proclaim.arity(WeakMap.prototype['delete'], 1);
+	proclaim.isFunction(WeakMap.prototype.delete);
+	proclaim.arity(WeakMap.prototype.delete, 1);
 	proclaim.isNotEnumerable(WeakMap.prototype, 'delete');
 	var a = {};
 	var b = {};
@@ -126,10 +126,10 @@ it('WeakMap.prototype.delete', function () {
 	M.set(b, 21);
 	proclaim.isTrue(M.has(a));
 	proclaim.isTrue(M.has(b));
-	M['delete'](a);
+	M.delete(a);
 	proclaim.isFalse(M.has(a));
 	proclaim.isTrue(M.has(b));
-	proclaim.isFalse(M['delete'](1));
+	proclaim.isFalse(M.delete(1));
 });
 
 it('WeakMap.prototype.get', function () {
@@ -142,7 +142,7 @@ it('WeakMap.prototype.get', function () {
 	proclaim.isUndefined(M.get({}));
 	M.set(a, 42);
 	proclaim.strictEqual(M.get(a), 42);
-	M['delete'](a);
+	M.delete(a);
 	proclaim.isUndefined(M.get(a));
 	proclaim.isUndefined(M.get(1));
 });
@@ -157,7 +157,7 @@ it('WeakMap.prototype.has', function () {
 	proclaim.isFalse(M.has({}));
 	M.set(a, 42);
 	proclaim.isTrue(M.has(a));
-	M['delete'](a);
+	M.delete(a);
 	proclaim.isFalse(M.has(a));
 	proclaim.isFalse(M.has(1));
 });
@@ -171,7 +171,7 @@ it('WeakMap.prototype.set', function () {
 	proclaim.isNotEnumerable(WeakMap.prototype, 'set');
 	wmap.set(a, 42);
 	proclaim.strictEqual(wmap.get(a), 42);
-	proclaim["throws"](function () {
+	proclaim.throws(function () {
 		new WeakMap().set(42, 42);
 	}, TypeError);
 	proclaim.deepEqual(wmap.set({}, 1), wmap);

--- a/polyfills/WeakSet/detect.js
+++ b/polyfills/WeakSet/detect.js
@@ -3,7 +3,7 @@
 		if (Object.prototype.hasOwnProperty.call(global, "WeakSet") && global.WeakSet.length === 0) {
 			var o = {};
 			var ws = new global.WeakSet([o]);
-			return (ws.has(o) && ws["delete"](0) === false);
+			return (ws.has(o) && ws.delete(0) === false);
 		} else {
 			return false;
 		}

--- a/polyfills/WeakSet/tests.js
+++ b/polyfills/WeakSet/tests.js
@@ -38,7 +38,7 @@ it('should be instantiable', function(){
 
 it('has add, delete and has methods', function(){
 	proclaim.notEqual(WeakSet.prototype.add, undefined);
-	proclaim.notEqual(WeakSet.prototype['delete'], undefined);
+	proclaim.notEqual(WeakSet.prototype.delete, undefined);
 	proclaim.notEqual(WeakSet.prototype.has, undefined);
 });
 
@@ -57,10 +57,10 @@ it('should perform as expected', function() {
 	proclaim.equal(set.has(d), true);
 	proclaim.equal(set.has(e), false);
 
-	proclaim.equal(set['delete'](b), true);
-	proclaim.equal(set['delete'](c), true);
-	proclaim.equal(set['delete'](d), true);
-	proclaim.equal(set['delete'](e), false);
+	proclaim.equal(set.delete(b), true);
+	proclaim.equal(set.delete(c), true);
+	proclaim.equal(set.delete(d), true);
+	proclaim.equal(set.delete(e), false);
 
 	proclaim.equal(set.has(a), true);
 	proclaim.equal(set.has(b), false);

--- a/polyfills/atob/tests.js
+++ b/polyfills/atob/tests.js
@@ -3,21 +3,21 @@
 
 // Doesn't throw in IE9, otherwise works fine, so tolerate this
 it.skip("should throw exception for invalid characters in code", function () {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3$VyZ");
 	});
 });
 
 // Doesn't throw in IE9, otherwise works fine, so tolerate this
 it.skip("should throw exception for too much padding", function () {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3VyZ===");
 	});
 });
 
 // Not supported by the polyfill, probably not a problem
 it.skip("should throw exception for badly formed base64", function () {
-	proclaim["throws"](function() {
+	proclaim.throws(function() {
 		atob("YW55IGNhcm5hbCBwbGVhc3VyZ");
 	});
 });

--- a/polyfills/globalThis/tests.js
+++ b/polyfills/globalThis/tests.js
@@ -28,13 +28,13 @@ describe("globalThis", function() {
 	});
 
 	it("is not possible to invoke the global object as a function", function() {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			globalThis();
 		}, TypeError);
 	});
 
 	it("is not possible to use the global object as a constructor  with the new operator", function() {
-		proclaim["throws"](function() {
+		proclaim.throws(function() {
 			new globalThis();
 		}, TypeError);
 	});

--- a/polyfills/queueMicrotask/polyfill.js
+++ b/polyfills/queueMicrotask/polyfill.js
@@ -11,7 +11,7 @@ self.queueMicrotask = function queueMicrotask(microtask) {
 	}
 
 	Promise.resolve()
-		.then(microtask)["catch"](function(e) {
+		.then(microtask).catch(function(e) {
 
 			// TODO: implement a ErrorEvent polyfill and use that instead
 			// new ErrorEvent("error", {

--- a/polyfills/queueMicrotask/tests.js
+++ b/polyfills/queueMicrotask/tests.js
@@ -7,23 +7,23 @@ describe('queueMicrotask', function() {
 	});
 
 	it('throws type error if an argument is 0', function() {
-		proclaim["throws"](function() { queueMicrotask(0) }, TypeError);
+		proclaim.throws(function() { queueMicrotask(0) }, TypeError);
 	});
 
 	it('throws type error if no argument is supplied', function() {
-		proclaim["throws"](function() { queueMicrotask() }, TypeError);
+		proclaim.throws(function() { queueMicrotask() }, TypeError);
 	});
 
 	it('throws type error if an argument is undefined', function() {
-		proclaim["throws"](function() { queueMicrotask(undefined) }, TypeError);
+		proclaim.throws(function() { queueMicrotask(undefined) }, TypeError);
 	});
 
 	it('throws type error if an argument is null', function() {
-		proclaim["throws"](function() { queueMicrotask(null) }, TypeError);
+		proclaim.throws(function() { queueMicrotask(null) }, TypeError);
 	});
 
 	it('throws type error if an argument is of a String type', function() {
-		proclaim["throws"](function() { queueMicrotask('test') }, TypeError);
+		proclaim.throws(function() { queueMicrotask('test') }, TypeError);
 	});
 
 	it('rethrows exceptions from the microtask callback', function(done) {

--- a/polyfills/requestIdleCallback/tests.js
+++ b/polyfills/requestIdleCallback/tests.js
@@ -8,7 +8,7 @@ describe('IdleDeadline', function () {
 	});
 
 	it('throws a type type error when used as a constructor', function () {
-		proclaim["throws"](function () {
+		proclaim.throws(function () {
 			new IdleDeadline();
 		}, TypeError);
 	});
@@ -17,7 +17,7 @@ describe('IdleDeadline', function () {
 	// error, except where getters aren't supported return undefined.
 	it('has a didTimeout prototype property which throws a type error when getters are supported or undefined otherwise', function () {
 		if (Object.prototype.hasOwnProperty.call(Object.prototype, '__defineGetter__')) {
-			proclaim["throws"](function () {
+			proclaim.throws(function () {
 				return IdleDeadline.prototype.didTimeout;
 			}, TypeError);
 		} else {
@@ -27,7 +27,7 @@ describe('IdleDeadline', function () {
 
 	it('has a timeRemaining prototype function which throws a type error', function () {
 		proclaim.isTypeOf(IdleDeadline.prototype.timeRemaining, 'function');
-		proclaim["throws"](IdleDeadline.prototype.timeRemaining, TypeError);
+		proclaim.throws(IdleDeadline.prototype.timeRemaining, TypeError);
 	});
 
 });
@@ -313,7 +313,7 @@ describe('cancelIdleCallback', function () {
 	});
 
 	it('should throw a type error if given no arguments', function () {
-		proclaim["throws"](cancelIdleCallback, TypeError);
+		proclaim.throws(cancelIdleCallback, TypeError);
 	});
 
 	it('cancels an idle callback', function (done) {


### PR DESCRIPTION
This PR updates the `dot-notation` ESLint rule to allow keywords (e.g. `proclaim.throws` instead of `proclaim['throws']`), and fixes all the violations.