### PR TITLE
Enable and document locally running polyfill tests

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -85,14 +85,14 @@ Browsers that can be listed:
 
 The browser list uses a form of semantic versioning to indicate which browser requires polyfilling.
 
-If all versions of a browser require the polyfill you can use the wildcard asterisk (*):
+If all versions of a browser require the polyfill you can use the wildcard asterisk (`*`):
 
 ```toml
 [browsers]
 android = "*"
 ```
 
-For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 8 and below you can use "<9":
+For specific versions you can specify a number, for example if a polyfill is required in Internet Explorer 8 and below you can use "`<9`":
 
 ```toml
 [browsers]
@@ -140,9 +140,31 @@ Setup you local environment :
 
 `$ npm install`
 
-Start the watcher :
+Start the build watcher :
 
 `$ npm run watch`
+
+Or build once using `npm run build`.
+
+### Testing locally
+
+You can run the tests locally in a headless browser, e.g. if you don't have BrowserStack
+credentials, are working offline, or want to run the tests in an isolated environment
+without access to your host machine.
+
+To run the `URL` tests once :
+
+```
+$ npm run test-polyfills -- --features=URL --browsers=FirefoxHeadless --singleRun=true
+
+...
+Finished in 0.019 secs
+
+SUMMARY:
+✔ 53 tests completed
+```
+
+### Testing with BrowserStack
 
 After a file change you will see :
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -115,6 +115,7 @@ module.exports = async function (config) {
 		plugins: [
 			'karma-mocha',
 			'karma-mocha-reporter',
+			'karma-firefox-launcher',
 			karmaPolyfillLibraryPlugin,
 			'karma-summary-optional-console-reporter'
 		],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3814,6 +3814,16 @@
         }
       }
     },
+    "karma-firefox-launcher": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-2.1.2.tgz",
+      "integrity": "sha512-VV9xDQU1QIboTrjtGVD4NCfzIH7n01ZXqy/qpBhnOeGVOkG5JYPEm8kuSd7psHE6WouZaQ9Ool92g8LFweSNMA==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^2.2.0",
+        "which": "^2.0.1"
+      }
+    },
     "karma-mocha": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "json3": "^3.3.2",
     "karma": "^6.0.0",
     "karma-browserstack-launcher": "^1.4.0",
+    "karma-firefox-launcher": "^2.1.2",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-summary-optional-console-reporter": "^1.6.1",


### PR DESCRIPTION
I was struggling to find a way to make the tests run locally, e.g. in a container or other development environment separate from your main desktop (e.g. [wikimedia/fresh](https://github.com/wikimedia/fresh/) or Vagrant-based environments, where you shell to a local container or VM).

Karma supports this very well, and I nearly got there without changing any files, but ran into the problem that Karma was each plugin to explicitly be loaded. The parameters `--browsers` and `--singleRun` can be passed to`karma start` from `npm run test-polyfills`, but this doesn't seem to work for enabling plugins, and besides, it's still suboptimal to manually install a launcher and dirtying the repo during development.

I hope this is of use. Happy to amend or otherwise accomodate any preferences to make it fit.