### PR TITLE
Fixes `HTMLSelectElement.prototype.remove` to include `Element.prototype.remove`

### DIFF
--- a/polyfills/Element/prototype/remove/polyfill.js
+++ b/polyfills/Element/prototype/remove/polyfill.js
@@ -9,3 +9,14 @@ Document.prototype.remove = Element.prototype.remove = function remove() {
 if ("Text" in self) {
 	Text.prototype.remove = Element.prototype.remove;
 }
+
+(function () {
+	var originalRemove = HTMLSelectElement.prototype.remove;
+
+	HTMLSelectElement.prototype.remove = function remove(index) {
+		if (typeof index === 'undefined') {
+			return Element.prototype.remove.call(this);
+		}
+		return originalRemove.call(this, index);
+	};
+})();

--- a/polyfills/Element/prototype/remove/tests.js
+++ b/polyfills/Element/prototype/remove/tests.js
@@ -38,3 +38,28 @@ it('can remove itself from nothing', function () {
 
 	proclaim.equal(element.childNodes.length, 0);
 });
+
+it('can remove a select', function () {
+	child.remove();
+
+	var select = document.createElement('select');
+	element.appendChild(select);
+
+	proclaim.equal(select.remove(), undefined);
+
+	proclaim.equal(element.childNodes.length, 0);
+});
+
+it('does not break the ability for a select to remove an option', function () {
+	child.remove();
+
+	var select = document.createElement('select');
+	var option = document.createElement('option');
+	element.appendChild(select);
+	select.appendChild(option);
+
+	proclaim.equal(select.remove(0), undefined);
+
+	proclaim.equal(select.childNodes.length, 0);
+	proclaim.equal(element.childNodes.length, 1);
+});


### PR DESCRIPTION
Resolves https://github.com/Financial-Times/polyfill-library/issues/1179.

See https://github.com/Financial-Times/polyfill-library/issues/1179#issuecomment-1092364449 for details.