### PR TITLE
fix partial tests in CI and use native concurrency control

### DIFF
--- a/.github/workflows/test-from-fork.yml
+++ b/.github/workflows/test-from-fork.yml
@@ -5,6 +5,10 @@ on:
 # Simplified workflow of ./test-polyfills.yml
 # Intended to be used by contributors on their forks.
 
+concurrency:
+  group: browserstack
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,6 +22,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+
+      # Fetch master branch to determine which polyfills have changed and need testing.
+      - run: |
+          git remote add upstream https://github.com/Financial-Times/polyfill-library.git
+          git fetch --depth=50 upstream master
 
       - uses: actions/setup-node@v2.2.0
         with:

--- a/.github/workflows/test-from-fork.yml
+++ b/.github/workflows/test-from-fork.yml
@@ -21,10 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 50
 
       # Fetch master branch to determine which polyfills have changed and need testing.
-      - run: |
+      - name: Fetch upstream to determine diff
+        run: |
           git remote add upstream https://github.com/Financial-Times/polyfill-library.git
           git fetch --depth=50 upstream master
 

--- a/.github/workflows/test-polyfills-weekly.yml
+++ b/.github/workflows/test-polyfills-weekly.yml
@@ -4,21 +4,11 @@ on:
     - cron: '0 23 * * 0' # TODO : set convenient weekly retest time
   workflow_dispatch:
 
+concurrency:
+  group: browserstack
+  cancel-in-progress: false
+
 jobs:
-  check-for-other-pull-requests-running-this-workflow:
-    runs-on: ubuntu-latest
-    if: ${{ github.pull_request.head.repo.fork == false}}
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc # pin@0.8.0
-        with:
-          access_token: ${{ github.token }}
-      - name: Turnstyle
-        uses: softprops/turnstyle@a714535c65d622af7010e609960ccf0ea5001e3f # pin@v1
-        with:
-          same-branch-only: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
     needs: [ check-for-other-pull-requests-running-this-workflow ]

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [ok-to-test-command]
 
+concurrency:
+  group: browserstack
+  cancel-in-progress: false
+
 jobs:
   # Branch-based pull request
   integration-trusted:
@@ -18,6 +22,11 @@ jobs:
 
     - name: Branch based PR checkout
       uses: actions/checkout@v2
+
+    # Fetch master branch to determine which polyfills have changed and need testing.
+    - run: |
+        git remote add upstream https://github.com/Financial-Times/polyfill-library.git
+        git fetch --depth=50 upstream master
 
     # <insert integration tests needing secrets>
     - uses: actions/setup-node@v2.2.0
@@ -66,6 +75,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
+      - run: |
+          git remote add upstream https://github.com/Financial-Times/polyfill-library.git
+          git fetch --depth=50 upstream master
 
       # <insert integration tests needing secrets>
       - uses: actions/setup-node@v2.2.0

--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -22,9 +22,12 @@ jobs:
 
     - name: Branch based PR checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
 
     # Fetch master branch to determine which polyfills have changed and need testing.
-    - run: |
+    - name: Fetch upstream to determine diff
+      run: |
         git remote add upstream https://github.com/Financial-Times/polyfill-library.git
         git fetch --depth=50 upstream master
 
@@ -75,8 +78,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+          fetch-depth: 50
 
-      - run: |
+      # Fetch master branch to determine which polyfills have changed and need testing.
+      - name: Fetch upstream to determine diff
+        run: |
           git remote add upstream https://github.com/Financial-Times/polyfill-library.git
           git fetch --depth=50 upstream master
 

--- a/.github/workflows/update-polyfill-targets.yml
+++ b/.github/workflows/update-polyfill-targets.yml
@@ -3,6 +3,11 @@ name: Update polyfill targets
 on:
   schedule:
     - cron: "0 6 1 1 *"
+
+concurrency:
+  group: browserstack
+  cancel-in-progress: false
+
 jobs:
   android:
     runs-on: ubuntu-latest

--- a/test/utils/modified-polyfills-with-tests.js
+++ b/test/utils/modified-polyfills-with-tests.js
@@ -185,10 +185,9 @@ function toposortPolyfills(polyfillMetas) {
 
 function getModifiedFiles() {
 	return new Promise((resolve) => {
-		const currentBranch = process.env.GITHUB_REF || 'HEAD'
 		const baseBranch = process.env.GITHUB_ACTIONS ? 'upstream/master' : 'master';
 
-		exec(`git --no-pager diff --name-only ${currentBranch} $(git merge-base ${currentBranch} ${baseBranch})`, (error, stdout, stderr) => {
+		exec(`git --no-pager diff --name-only HEAD $(git merge-base --fork-point ${baseBranch})`, (error, stdout, stderr) => {
 			if (error) {
 				console.warn(`error while getting modified files : ${error.message}`);
 				resolve([]);


### PR DESCRIPTION
GitHub workflows have build in concurrency controls.
Using these means we can remove `styfle/cancel-workflow-action` and `softprops/turnstyle`. Two 3rd party actions that required access to secrets.

Partial tests seem to have broken a while back because the checkout step no longer fetched `https://github.com/Financial-Times/polyfill-library/tree/master/`. This is required to determine the diff.

update : maybe this was done because `GITHUB_REF` was no longer valid when workflows run with a `pull_request` event. The JS has been updated so that it works for any trigger.

I've added a fetch depth of 50 which is much larger than usual pull requests will require but still smaller than fetching everything.