### PR TITLE
Adds polyfills for `TypedArray.prototype` methods

### DIFF
--- a/polyfills/TypedArray/prototype/@@iterator/config.toml
+++ b/polyfills/TypedArray/prototype/@@iterator/config.toml
@@ -1,0 +1,21 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"ArrayBuffer",
+	"Symbol.iterator",
+	"TypedArray.prototype.values",
+]
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype-@@iterator"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator"
+
+[browsers]
+android = "*"
+chrome = "<38"
+firefox = "<36"
+ie = "*"
+ie_mob = "*"
+opera = "<25"
+op_mob = "<25"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<3"

--- a/polyfills/TypedArray/prototype/@@iterator/detect.js
+++ b/polyfills/TypedArray/prototype/@@iterator/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Symbol' in self && 'iterator' in self.Symbol && 'Int8Array' in self && self.Symbol.iterator in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/@@iterator/polyfill.js
+++ b/polyfills/TypedArray/prototype/@@iterator/polyfill.js
@@ -1,0 +1,20 @@
+/* global Symbol, CreateMethodProperty */
+// 23.2.3.34 %TypedArray%.prototype [ @@iterator ] ( )
+// The initial value of the @@iterator property is %TypedArray.prototype.values%
+
+// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+// in that case, don't define it on the parent; define it directly on the prototype
+if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+	// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+	CreateMethodProperty(self.Int8Array.prototype.__proto__, Symbol.iterator, self.Int8Array.prototype.__proto__.values);
+} else {
+	CreateMethodProperty(self.Int8Array.prototype, Symbol.iterator, self.Int8Array.prototype.values);
+	CreateMethodProperty(self.Uint8Array.prototype, Symbol.iterator, self.Uint8Array.prototype.values);
+	CreateMethodProperty(self.Uint8ClampedArray.prototype, Symbol.iterator, self.Uint8ClampedArray.prototype.values);
+	CreateMethodProperty(self.Int16Array.prototype, Symbol.iterator, self.Int16Array.prototype.values);
+	CreateMethodProperty(self.Uint16Array.prototype, Symbol.iterator, self.Uint16Array.prototype.values);
+	CreateMethodProperty(self.Int32Array.prototype, Symbol.iterator, self.Int32Array.prototype.values);
+	CreateMethodProperty(self.Uint32Array.prototype, Symbol.iterator, self.Uint32Array.prototype.values);
+	CreateMethodProperty(self.Float32Array.prototype, Symbol.iterator, self.Float32Array.prototype.values);
+	CreateMethodProperty(self.Float64Array.prototype, Symbol.iterator, self.Float64Array.prototype.values);
+}

--- a/polyfills/TypedArray/prototype/@@iterator/tests.js
+++ b/polyfills/TypedArray/prototype/@@iterator/tests.js
@@ -1,0 +1,11 @@
+/* globals proclaim, Symbol, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is an alias to %TypedArray%.prototype.values', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.deepEqual(Int8Array.prototype.__proto__[Symbol.iterator], Int8Array.prototype.__proto__.values);
+	} else {
+		proclaim.deepEqual(Int8Array.prototype[Symbol.iterator], Int8Array.prototype.values);
+	}
+});

--- a/polyfills/TypedArray/prototype/entries/config.toml
+++ b/polyfills/TypedArray/prototype/entries/config.toml
@@ -1,0 +1,24 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ArrayIterator",
+	"_ESAbstract.CreateMethodProperty",
+	"ArrayBuffer",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/entries"
+
+[browsers]
+android = "*"
+chrome = "<45"
+edge = "<14"
+edge_mob = "<14"
+firefox = "<37"
+firefox_mob = "<37"
+ie = "*"
+ie_mob = "*"
+opera = "<36"
+op_mob = "<36"
+safari = "<9.1"
+ios_saf = "<9.3"
+samsung_mob = "<5"

--- a/polyfills/TypedArray/prototype/entries/detect.js
+++ b/polyfills/TypedArray/prototype/entries/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'entries' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/entries/polyfill.js
+++ b/polyfills/TypedArray/prototype/entries/polyfill.js
@@ -1,0 +1,36 @@
+/* global CreateMethodProperty, ArrayIterator */
+// 23.2.3.7 %TypedArray%.prototype.entries ( )
+(function () {
+	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+
+	function createMethodProperties (fn) {
+		var fnName = 'entries'
+
+		// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+		// in that case, don't define it on the parent; define it directly on the prototype
+		if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+			// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+			CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, fn);
+		} else {
+			CreateMethodProperty(self.Int8Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint8Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, fn);
+			CreateMethodProperty(self.Int16Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint16Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Int32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Float32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Float64Array.prototype, fnName, fn);
+		}
+	}
+
+	createMethodProperties(function entries () {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? ValidateTypedArray(O).
+		// TODO: Add ValidateTypedArray
+		// 3. Return CreateArrayIterator(O, key).
+		// TODO: Add CreateArrayIterator
+		return new ArrayIterator(O, 'key+value');
+	});
+})();

--- a/polyfills/TypedArray/prototype/entries/tests.js
+++ b/polyfills/TypedArray/prototype/entries/tests.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha, browser */
+/* global proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is a function', function () {
+	proclaim.isFunction(Int8Array.prototype.entries);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Int8Array.prototype.entries, 0);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Int8Array.prototype.entries, 'entries');
+});
+
+it('is not enumerable', function () {
+	if ('__proto__' in Int8Array.prototype && Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isNotEnumerable(Int8Array.prototype.__proto__, 'entries');
+	} else {
+		proclaim.isNotEnumerable(Int8Array.prototype, 'entries');
+	}
+});
+
+describe('entries', function () {
+	it('returns a next-able object', function () {
+		var array = new Int8Array([10, 11]);
+		var iterator = array.entries();
+
+		proclaim.isInstanceOf(iterator.next, Function);
+		proclaim.deepEqual(iterator.next(), {
+			value: [0, 10],
+			done: false
+		});
+	});
+
+	it('finally returns a done object', function () {
+		var array = new Int8Array([10, 11]);
+		var iterator = array.entries();
+		iterator.next();
+		iterator.next();
+		proclaim.deepEqual(iterator.next(), {
+			value: undefined,
+			done: true
+		});
+	});
+});

--- a/polyfills/TypedArray/prototype/keys/config.toml
+++ b/polyfills/TypedArray/prototype/keys/config.toml
@@ -1,0 +1,24 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ArrayIterator",
+	"_ESAbstract.CreateMethodProperty",
+	"ArrayBuffer",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys"
+
+[browsers]
+android = "*"
+chrome = "<38"
+edge = "<14"
+edge_mob = "<14"
+firefox = "<37"
+firefox_mob = "<37"
+ie = "*"
+ie_mob = "*"
+opera = "<25"
+op_mob = "<25"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<3"

--- a/polyfills/TypedArray/prototype/keys/detect.js
+++ b/polyfills/TypedArray/prototype/keys/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'keys' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/keys/polyfill.js
+++ b/polyfills/TypedArray/prototype/keys/polyfill.js
@@ -1,0 +1,36 @@
+/* global CreateMethodProperty, ArrayIterator */
+// 23.2.3.19 %TypedArray%.prototype.keys ( )
+(function () {
+	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+
+	function createMethodProperties (fn) {
+		var fnName = 'keys'
+
+		// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+		// in that case, don't define it on the parent; define it directly on the prototype
+		if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+			// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+			CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, fn);
+		} else {
+			CreateMethodProperty(self.Int8Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint8Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, fn);
+			CreateMethodProperty(self.Int16Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint16Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Int32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Float32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Float64Array.prototype, fnName, fn);
+		}
+	}
+
+	createMethodProperties(function keys () {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? ValidateTypedArray(O).
+		// TODO: Add ValidateTypedArray
+		// 3. Return CreateArrayIterator(O, key).
+		// TODO: Add CreateArrayIterator
+		return new ArrayIterator(O, 'key');
+	});
+})();

--- a/polyfills/TypedArray/prototype/keys/tests.js
+++ b/polyfills/TypedArray/prototype/keys/tests.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha, browser */
+/* global proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is a function', function () {
+	proclaim.isFunction(Int8Array.prototype.keys);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Int8Array.prototype.keys, 0);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Int8Array.prototype.keys, 'keys');
+});
+
+it('is not enumerable', function () {
+	if ('__proto__' in Int8Array.prototype && Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isNotEnumerable(Int8Array.prototype.__proto__, 'keys');
+	} else {
+		proclaim.isNotEnumerable(Int8Array.prototype, 'keys');
+	}
+});
+
+describe('keys', function () {
+	it('returns a next-able object', function () {
+		var array = new Int8Array([10, 11]);
+		var iterator = array.keys();
+
+		proclaim.isInstanceOf(iterator.next, Function);
+		proclaim.deepEqual(iterator.next(), {
+			value: 0,
+			done: false
+		});
+	});
+
+	it('finally returns a done object', function () {
+		var array = new Int8Array([10, 11]);
+		var iterator = array.keys();
+		iterator.next();
+		iterator.next();
+		proclaim.deepEqual(iterator.next(), {
+			value: undefined,
+			done: true
+		});
+	});
+});

--- a/polyfills/TypedArray/prototype/toLocaleString/config.toml
+++ b/polyfills/TypedArray/prototype/toLocaleString/config.toml
@@ -1,0 +1,19 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"ArrayBuffer",
+]
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString"
+
+[browsers]
+android = "*"
+chrome = "<7"
+firefox = "<51"
+ie = "<10"
+ie_mob = "<10"
+opera = "<11.6"
+op_mob = "<12"
+safari = "<5.1"
+ios_saf = "<5.0"
+samsung_mob = "<1"

--- a/polyfills/TypedArray/prototype/toLocaleString/detect.js
+++ b/polyfills/TypedArray/prototype/toLocaleString/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'toLocaleString' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/toLocaleString/polyfill.js
+++ b/polyfills/TypedArray/prototype/toLocaleString/polyfill.js
@@ -1,0 +1,29 @@
+/* global CreateMethodProperty */
+// 23.2.3.31 %TypedArray%.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] )
+(function () {
+	var fnName = 'toLocaleString'
+
+	// %TypedArray%.prototype.toLocaleString is a distinct function that implements the same algorithm as Array.prototype.toLocaleString
+	function toLocaleString () {
+		return Array.prototype.toLocaleString.call(this, arguments);
+	}
+
+	// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+	// in that case, don't define it on the parent; define it directly on the prototype
+	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, toLocaleString);
+	} else {
+		CreateMethodProperty(self.Int8Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Uint8Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Int16Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Uint16Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Int32Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Uint32Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Float32Array.prototype, fnName, toLocaleString);
+		CreateMethodProperty(self.Float64Array.prototype, fnName, toLocaleString);
+	}
+})();

--- a/polyfills/TypedArray/prototype/toLocaleString/tests.js
+++ b/polyfills/TypedArray/prototype/toLocaleString/tests.js
@@ -1,0 +1,43 @@
+/* globals proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is a function', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isFunction(Int8Array.prototype.__proto__.toLocaleString);
+	} else {
+		proclaim.isFunction(Int8Array.prototype.toLocaleString);
+	}
+});
+
+it('has correct arity', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.arity(Int8Array.prototype.__proto__.toLocaleString, 0);
+	} else {
+		proclaim.arity(Int8Array.prototype.toLocaleString, 0);
+	}
+});
+
+it('has correct name', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.hasName(Int8Array.prototype.__proto__.toLocaleString, 'toLocaleString');
+	} else {
+		proclaim.hasName(Int8Array.prototype.toLocaleString, 'toLocaleString');
+	}
+});
+
+it('is not enumerable', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isNotEnumerable(Int8Array.prototype.__proto__, 'toLocaleString');
+	} else {
+		proclaim.isNotEnumerable(Int8Array.prototype, 'toLocaleString');
+	}
+});
+
+describe('toLocaleString', function () {
+	it('has the same result as Array.prototype.toLocaleString', function () {
+		var typedArray = new Int8Array([10, 11]);
+		var array = [10, 11];
+		proclaim.equal(typedArray.toLocaleString(), array.toLocaleString());
+	});
+});

--- a/polyfills/TypedArray/prototype/toString/config.toml
+++ b/polyfills/TypedArray/prototype/toString/config.toml
@@ -1,0 +1,18 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"ArrayBuffer",
+]
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tostring"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString"
+
+[browsers]
+android = "*"
+chrome = "<7"
+firefox = "<51"
+ie = "<10"
+ie_mob = "<10"
+opera = "<11.6"
+op_mob = "<12"
+safari = "<5.1"
+ios_saf = "<5.0"

--- a/polyfills/TypedArray/prototype/toString/detect.js
+++ b/polyfills/TypedArray/prototype/toString/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'toString' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/toString/polyfill.js
+++ b/polyfills/TypedArray/prototype/toString/polyfill.js
@@ -1,0 +1,27 @@
+/* global CreateMethodProperty */
+// 23.2.3.32 %TypedArray%.prototype.toString ( )
+// The initial value of the "toString" property is %Array.prototype.toString%
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+(function () {
+	var fnName = 'toString'
+	var fn = Array.prototype.toString
+
+	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+	// in that case, don't define it on the parent; define it directly on the prototype
+	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, fn);
+	} else {
+		CreateMethodProperty(self.Int8Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Uint8Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, fn);
+		CreateMethodProperty(self.Int16Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Uint16Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Int32Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Uint32Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Float32Array.prototype, fnName, fn);
+		CreateMethodProperty(self.Float64Array.prototype, fnName, fn);
+	}
+})();

--- a/polyfills/TypedArray/prototype/toString/tests.js
+++ b/polyfills/TypedArray/prototype/toString/tests.js
@@ -1,0 +1,11 @@
+/* globals proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is an alias to Array.prototype.toString', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.deepEqual(Int8Array.prototype.__proto__.toString, Array.prototype.toString);
+	} else {
+		proclaim.deepEqual(Int8Array.prototype.toString, Array.prototype.toString);
+	}
+});

--- a/polyfills/TypedArray/prototype/values/config.toml
+++ b/polyfills/TypedArray/prototype/values/config.toml
@@ -1,0 +1,24 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ArrayIterator",
+	"_ESAbstract.CreateMethodProperty",
+	"ArrayBuffer",
+]
+license = "MIT"
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.values"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/values"
+
+[browsers]
+android = "*"
+chrome = "<38"
+edge = "<14"
+edge_mob = "<14"
+firefox = "<37"
+firefox_mob = "<37"
+ie = "*"
+ie_mob = "*"
+opera = "<25"
+op_mob = "<25"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<3"

--- a/polyfills/TypedArray/prototype/values/detect.js
+++ b/polyfills/TypedArray/prototype/values/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'values' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/values/polyfill.js
+++ b/polyfills/TypedArray/prototype/values/polyfill.js
@@ -1,0 +1,41 @@
+/* global CreateMethodProperty, Symbol, ArrayIterator */
+// 23.2.3.33 %TypedArray%.prototype.values ( )
+(function () {
+	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+
+	function createMethodProperties (fn) {
+		var fnName = 'values'
+
+		// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+		// in that case, don't define it on the parent; define it directly on the prototype
+		if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+			// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+			CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, fn);
+		} else {
+			CreateMethodProperty(self.Int8Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint8Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, fn);
+			CreateMethodProperty(self.Int16Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint16Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Int32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Uint32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Float32Array.prototype, fnName, fn);
+			CreateMethodProperty(self.Float64Array.prototype, fnName, fn);
+		}
+	}
+
+	// Polyfill.io - Firefox, Chrome and Opera have %TypedArray%.prototype[Symbol.iterator], which is the exact same function as %TypedArray%.prototype.values.
+	if ('Symbol' in self && 'iterator' in Symbol && typeof self.Int8Array.prototype[Symbol.iterator] === 'function') {
+		createMethodProperties(self.Int8Array.prototype[Symbol.iterator])
+	} else {
+		createMethodProperties(function values () {
+			// 1. Let O be the this value.
+			var O = this;
+			// 2. Perform ? ValidateTypedArray(O).
+			// TODO: Add ValidateTypedArray
+			// 3. Return CreateArrayIterator(O, value).
+			// TODO: Add CreateArrayIterator
+			return new ArrayIterator(O, 'value');
+		});
+	}
+})();

--- a/polyfills/TypedArray/prototype/values/tests.js
+++ b/polyfills/TypedArray/prototype/values/tests.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha, browser */
+/* global proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is a function', function () {
+	proclaim.isFunction(Int8Array.prototype.values);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Int8Array.prototype.values, 0);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Int8Array.prototype.values, 'values');
+});
+
+it('is not enumerable', function () {
+	if ('__proto__' in Int8Array.prototype && Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isNotEnumerable(Int8Array.prototype.__proto__, 'values');
+	} else {
+		proclaim.isNotEnumerable(Int8Array.prototype, 'values');
+	}
+});
+
+describe('values', function () {
+	it('returns a next-able object', function () {
+		var array = new Int8Array([10, 11]);
+		var iterator = array.values();
+
+		proclaim.isInstanceOf(iterator.next, Function);
+		proclaim.deepEqual(iterator.next(), {
+			value: 10,
+			done: false
+		});
+	});
+
+	it('finally returns a done object', function () {
+		var array = new Int8Array([10, 11]);
+		var iterator = array.values();
+		iterator.next();
+		iterator.next();
+		proclaim.deepEqual(iterator.next(), {
+			value: undefined,
+			done: true
+		});
+	});
+});


### PR DESCRIPTION
This PR adds the following polyfills:
* `TypedArray.prototype.@@iterator`
* `TypedArray.prototype.entries`
* `TypedArray.prototype.keys`
* `TypedArray.prototype.toLocaleString`
* `TypedArray.prototype.toString`
* `TypedArray.prototype.values`

These are all noted as missing in the `ArrayBuffer` [polyfill](https://github.com/inexorabletash/polyfill/blob/716a3f36ca10fad032083014faf1a47c638e2502/typedarray.js) (i.e. [link](https://github.com/inexorabletash/polyfill/blob/716a3f36ca10fad032083014faf1a47c638e2502/typedarray.js#L500-L501), [link](https://github.com/inexorabletash/polyfill/blob/716a3f36ca10fad032083014faf1a47c638e2502/typedarray.js#L648-L649), [link](https://github.com/inexorabletash/polyfill/blob/716a3f36ca10fad032083014faf1a47c638e2502/typedarray.js#L891-L896)).