### PR TITLE
Update Safari support for Intl.ListFormat

### DIFF
--- a/polyfills/Intl/ListFormat/config.toml
+++ b/polyfills/Intl/ListFormat/config.toml
@@ -26,7 +26,7 @@ ie = ">=9"
 ie_mob = ">=9"
 opera = "<60"
 op_mob = "<51"
-safari = "*"
+safari = "<14.1"
 ios_saf = "<14.5"
 samsung_mob = "<11"
 


### PR DESCRIPTION
According to the [release note](https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes), Safari >= 14.1 has native support for `Intl.ListFormat`.