### PR TITLE
TypedArray.prototype.toLocaleString : Intl interop

### DIFF
--- a/polyfills/TypedArray/prototype/toLocaleString/config.toml
+++ b/polyfills/TypedArray/prototype/toLocaleString/config.toml
@@ -2,9 +2,13 @@ aliases = [ "es6", "es2015" ]
 dependencies = [
 	"_ESAbstract.CreateMethodProperty",
 	"ArrayBuffer",
+	"Intl.NumberFormat.~locale.en",
 ]
 spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring"
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString"
+notes = [
+	"Locales must be specified separately by prefixing the locale name with `Intl.NumberFormat.~locale`, eg `Intl.NumberFormat.~locale.en-GB`."
+]
 
 [browsers]
 android = "*"


### PR DESCRIPTION
add `Intl.NumberFormat.~locale.en` as a dependency

fixes : #1212 