### PR TITLE
Adds polyfill for `Object.prototype.toString`

### DIFF
--- a/polyfills/Object/prototype/toString/config.toml
+++ b/polyfills/Object/prototype/toString/config.toml
@@ -1,0 +1,25 @@
+aliases = [ "es6", "es2015" ]
+dependencies = [
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.Get",
+	"_ESAbstract.ToObject",
+	"_ESAbstract.Type",
+	"Symbol.toStringTag",
+]
+spec = "https://tc39.es/ecma262/#sec-object.prototype.tostring"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString"
+
+[browsers]
+android = "*"
+bb = "10 - *"
+chrome = "<49"
+edge = "<15"
+edge_mob = "<15"
+firefox = "<51"
+ie = "*"
+ie_mob = "*"
+opera = "<36"
+op_mob = "<36"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<5"

--- a/polyfills/Object/prototype/toString/detect.js
+++ b/polyfills/Object/prototype/toString/detect.js
@@ -1,0 +1,6 @@
+'Symbol' in self && 'toStringTag' in self.Symbol && 'toString' in Object.prototype &&
+	(function () {
+		var x = {}
+		x[self.Symbol.toStringTag] = 'x'
+		return Object.prototype.toString.call(x) === '[object x]'
+	})() === true

--- a/polyfills/Object/prototype/toString/polyfill.js
+++ b/polyfills/Object/prototype/toString/polyfill.js
@@ -1,0 +1,37 @@
+/* global CreateMethodProperty, Get, Symbol, ToObject, Type */
+
+// 20.1.3.6 Object.prototype.toString ( )
+(function () {
+	var ObjectProtoToStringOriginal = Object.prototype.toString;
+
+	CreateMethodProperty(Object.prototype, 'toString', function toString () {
+		'use strict';
+
+		// 1. If the this value is undefined, return "[object Undefined]".
+		if (this === undefined) return '[object Undefined]';
+		// 2. If the this value is null, return "[object Null]".
+		if (this === null) return '[object Null]';
+		// 3. Let O be ! ToObject(this value).
+		var O = ToObject(this);
+
+		// Polyfill.io - We will not implement these; we will use the original `Object.prototype.toString` to determine the object class
+		// 4. Let isArray be ? IsArray(O).
+		// 5. If isArray is true, let builtinTag be "Array".
+		// 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".
+		// 7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
+		// 8. Else if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
+		// 9. Else if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
+		// 10. Else if O has a [[NumberData]] internal slot, let builtinTag be "Number".
+		// 11. Else if O has a [[StringData]] internal slot, let builtinTag be "String".
+		// 12. Else if O has a [[DateValue]] internal slot, let builtinTag be "Date".
+		// 13. Else if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
+		// 14. Else, let builtinTag be "Object".
+
+		// 15. Let tag be ? Get(O, @@toStringTag).
+		var tag = Get(O, Symbol.toStringTag);
+		// 16. If Type(tag) is not String, set tag to builtinTag.
+		if (Type(tag) !== 'string') return ObjectProtoToStringOriginal.call(O);
+		// 17. Return the string-concatenation of "[object ", tag, and "]".
+		return '[object ' + tag + ']';
+	});
+})();

--- a/polyfills/Object/prototype/toString/tests.js
+++ b/polyfills/Object/prototype/toString/tests.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha, browser */
+/* global proclaim, Symbol */
+
+var hasStrictMode = (function () {
+	'use strict';
+	return this === null;
+}).call(null);
+
+it('is a function', function () {
+	proclaim.isFunction(Object.prototype.toString);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Object.prototype.toString, 0);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Object.prototype.toString, 'toString');
+});
+
+it('is not enumerable', function () {
+	proclaim.isNotEnumerable(Object.prototype, 'toString');
+});
+
+it('returns the class of an object without toStringTag', function () {
+	proclaim.equal(Object.prototype.toString.call(undefined), hasStrictMode ? '[object Undefined]' : '[object Null]');
+	proclaim.equal(Object.prototype.toString.call(null), '[object Null]');
+	proclaim.equal(Object.prototype.toString.call({}), '[object Object]');
+	proclaim.equal(Object.prototype.toString.call([]), '[object Array]');
+	proclaim.equal(Object.prototype.toString.call(new Error()), '[object Error]');
+});
+
+it('returns the class of an object with toStringTag', function () {
+	var x = {};
+	x[Symbol.toStringTag] = 'x';
+	proclaim.equal(Object.prototype.toString.call(x), '[object x]');
+});


### PR DESCRIPTION
This PR adds a polyfill for `Object.prototype.toString` that includes `Symbol.toStringTag` support.