### PR TITLE
ensure browser cache when testing polyfill combinations

### DIFF
--- a/test/polyfills/server.js
+++ b/test/polyfills/server.js
@@ -272,6 +272,7 @@ function createEndpoint(template) {
 				requestedFeature: features.length > 0,
 				features: features.map(f => f.feature).join(','),
 				includePolyfills: includePolyfills,
+				requestedPolyfillCombinations: polyfillCombinations === 'yes',
 				polyfillCombinations: polyfillCombinations,
 				always: always,
 				afterTestSuite: `

--- a/test/polyfills/test-iframe.handlebars
+++ b/test/polyfills/test-iframe.handlebars
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Test Iframe</title>
-	<script src="/polyfill.js?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}&feature={{features}}"></script>
+	<script src="/polyfill.js?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}{{#unless requestedPolyfillCombinations}}&feature={{features}}{{/unless}}"></script>
 </head>
 <body>
 	{{!-- Possibly add fixtures here --}}

--- a/test/polyfills/test-runner.handlebars
+++ b/test/polyfills/test-runner.handlebars
@@ -7,7 +7,7 @@
 
 	<link rel="stylesheet" type="text/css" href="/mocha.css">
 	<meta id="test-iframe-src" name="test-iframe-src" content="/iframe.html?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}&feature={{features}}">
-	<script src="/polyfill.js?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}&feature={{features}}"></script>
+	<script src="/polyfill.js?includePolyfills={{{includePolyfills}}}&always={{{always}}}&polyfillCombinations={{{polyfillCombinations}}}{{#unless requestedPolyfillCombinations}}&feature={{features}}{{/unless}}"></script>
 	<script src="/mocha.js"></script>
 	<script src="/proclaim.js"></script>
 	<script>mocha.setup('bdd');</script>


### PR DESCRIPTION
The polyfill bundles are very large in this case.
If they all have a unique url we will have nothing but cache misses have to wait for network, parsing, interpreting,...

This change makes the url the same for all tests if the bundle includes all polyfills anyway.