### PR TITLE
Revert "Bump @formatjs/intl-datetimeformat"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -338,35 +338,13 @@
       }
     },
     "@formatjs/intl-datetimeformat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-5.0.2.tgz",
-      "integrity": "sha512-yk7CItBMgtUsub123+iqOfXoqG6JHJIl3Pke7eOYb7QFAPsOZliAJb2i0+Tr1FXWcm1PdWZVHEv6C2l4nEmQdw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-4.1.0.tgz",
+      "integrity": "sha512-rEAPnIIsiOpjXMqoMdxClJ4Q2uhKTN1WH2fQUCJrg4FYdqfevJeymSowdLcOi1AYARIoTXTmlqS8pHIJx62VEw==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
+        "@formatjs/ecma402-abstract": "1.8.0",
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@formatjs/ecma402-abstract": {
-          "version": "1.11.4",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
-          "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
-          "dev": true,
-          "requires": {
-            "@formatjs/intl-localematcher": "0.2.25",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@formatjs/intl-localematcher": {
-          "version": "0.2.25",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
-          "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "@formatjs/intl-displaynames": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "toposort": "^2.0.2"
   },
   "devDependencies": {
-    "@formatjs/intl-datetimeformat": "5.0.2",
+    "@formatjs/intl-datetimeformat": "4.1.0",
     "@formatjs/intl-displaynames": "5.1.0",
     "@formatjs/intl-getcanonicallocales": "1.6.0",
     "@formatjs/intl-listformat": "6.1.0",

--- a/polyfills/Intl/DateTimeFormat/tests.js
+++ b/polyfills/Intl/DateTimeFormat/tests.js
@@ -4179,18 +4179,3 @@ it("should fix dayperiod bug in chrome", function () {
 	proclaim.ok(dayPeriod);
 	proclaim.notOk(dayperiod);
 });
-
-it("toLocaleString should return 'Invalid Date'", function () {
-	var date = new Date('').toLocaleString('en-US');
-	proclaim.equal(date, 'Invalid Date');
-});
-
-it("toLocaleTimeString should return 'Invalid Date'", function () {
-	var date = new Date('').toLocaleTimeString('en-US');
-	proclaim.equal(date, 'Invalid Date');
-});
-
-it("toLocaleDateString should return 'Invalid Date'", function () {
-	var date = new Date('').toLocaleDateString('en-US');
-	proclaim.equal(date, 'Invalid Date');
-});


### PR DESCRIPTION
Reverts Financial-Times/polyfill-library#1186

This change seems to have a serious performance regression.
Tests with polyfill combinations always give a timeout now in Chrome, Firefox and IE.