### PR TITLE
Adds `Node.prototype.getRootNode` and `Node.prototype.isConnected` polyfills

### DIFF
--- a/polyfills/Node/prototype/getRootNode/config.toml
+++ b/polyfills/Node/prototype/getRootNode/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = []
+
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode"
+spec = "https://dom.spec.whatwg.org/#dom-node-getrootnode"
+
+[browsers]
+android = "<6"
+bb = "*"
+chrome = "<54"
+edge = "*"
+edge_mob = "*"
+firefox = "<53"
+firefox_mob = "<53"
+ie = "*"
+ie_mob = "*"
+opera = "<41"
+op_mob = "<41"
+op_mini = "*"
+safari = "<10.1"
+ios_saf = "<10.3"
+samsung_mob = "<6"

--- a/polyfills/Node/prototype/getRootNode/detect.js
+++ b/polyfills/Node/prototype/getRootNode/detect.js
@@ -1,0 +1,1 @@
+document.getRootNode

--- a/polyfills/Node/prototype/getRootNode/polyfill.js
+++ b/polyfills/Node/prototype/getRootNode/polyfill.js
@@ -1,0 +1,58 @@
+(function() {
+	'use strict';
+
+	/**
+	 * Returns `this`’s shadow-including root if options’s `composed` is true.
+	 * Returns `this`’s root otherwise.
+	 *
+	 * The root of an object is itself, if its parent is null, or else it is the root of its parent.
+	 *
+	 * The shadow-including root of an object is its root’s host’s shadow-including root,
+	 * if the object’s root is a shadow root, and its root otherwise.
+	 *
+	 * https://dom.spec.whatwg.org/#dom-node-getrootnode
+	 *
+	 */
+	function getRootNode() {
+		var options = arguments[0];
+		var composed = typeof options === 'object' && Boolean(options.composed);
+
+		return composed ? getShadowIncludingRoot(this) : getRoot(this);
+	}
+
+	function getShadowIncludingRoot(node) {
+		var root = getRoot(node);
+
+		if (isShadowRoot(root)) {
+			return getShadowIncludingRoot(root.host);
+		}
+
+		return root;
+	}
+
+	function getRoot(node) {
+		if (node.parentNode != null) {
+			return getRoot(node.parentNode);
+		}
+
+		return node;
+	}
+
+	function isShadowRoot(node) {
+		return node.nodeName === '#document-fragment' && node.constructor.name === 'ShadowRoot';
+	}
+
+	// IE
+	if ('HTMLElement' in self && 'getRootNode' in HTMLElement.prototype) {
+		try {
+			delete HTMLElement.prototype.getRootNode;
+			// eslint-disable-next-line no-empty
+		} catch (e) {}
+	}
+
+	if ('Node' in self) {
+		Node.prototype.getRootNode = getRootNode;
+	} else {
+		document.getRootNode = Element.prototype.getRootNode = getRootNode;
+	}
+}());

--- a/polyfills/Node/prototype/getRootNode/tests.js
+++ b/polyfills/Node/prototype/getRootNode/tests.js
@@ -1,0 +1,152 @@
+/* eslint-env mocha */
+/* globals proclaim */
+
+function supportsShadowRoot() {
+	return typeof Element.prototype.attachShadow === "function";
+}
+
+describe('on an element', function () {
+	var element = document.createElement('div');
+
+	it("is a function", function() {
+		proclaim.isFunction(element.getRootNode);
+	});
+
+	it("has correct arity", function() {
+		proclaim.arity(element.getRootNode, 0);
+	});
+
+	it("has correct name", function() {
+		proclaim.hasName(element.getRootNode, "getRootNode");
+	});
+
+	function createShadowRoot(document) {
+		var node = document.createElement("div");
+		document.body.appendChild(node);
+		var shadowRoot = node.attachShadow({ mode: "open" });
+		var shadowNode = document.createElement("div");
+		shadowRoot.appendChild(shadowNode);
+
+		return { root: shadowRoot, node: shadowNode };
+	}
+
+	describe("returns the root of detached trees", function testGetRootDetached() {
+		function run(document) {
+			var rootNode = document.createElement("div");
+			var childNode = document.createElement("div");
+			var descendantNode = document.createElement("div");
+
+			rootNode.appendChild(childNode);
+			childNode.appendChild(descendantNode);
+
+			proclaim.deepStrictEqual(descendantNode.getRootNode(), rootNode);
+		}
+
+		it("current realm", function inRealm() {
+			run(document);
+		});
+	});
+
+	describe("returns the root of attached trees", function testGetRootAttached() {
+		function run(document) {
+			var rootNode = document.createElement("div");
+			var childNode = document.createElement("div");
+			var descendantNode = document.createElement("div");
+
+			document.body.appendChild(rootNode);
+			rootNode.appendChild(childNode);
+			childNode.appendChild(descendantNode);
+
+			proclaim.deepStrictEqual(descendantNode.getRootNode(), document);
+		}
+
+		it("current realm", function inRealm() {
+			run(document);
+		});
+	});
+
+	describe("returns itself if it is the root", function testGetSelf() {
+		function run(document) {
+			var detachedNode = document.createElement("div");
+
+			proclaim.deepStrictEqual(detachedNode.getRootNode(), detachedNode);
+			proclaim.deepStrictEqual(document.getRootNode(), document);
+		}
+
+		it("current realm", function inRealm() {
+			run(document);
+		});
+	});
+
+	describe("works with shadow roots", function testGetShadow() {
+		function run(document) {
+			var elems = createShadowRoot(document);
+			proclaim.deepStrictEqual(elems.node.getRootNode(), elems.root);
+		}
+
+		it("current realm", function inRealm() {
+			if (!supportsShadowRoot()) {
+				this.skip();
+				return;
+			}
+
+			run(document);
+		});
+	});
+
+	describe("\"composed\" option returns the shadow root's host's root", function testGetShadowsRoot() {
+		function run(document) {
+			var elems = createShadowRoot(document);
+			proclaim.deepStrictEqual(
+				elems.node.getRootNode({ composed: true }),
+				document
+			);
+		}
+
+		it("current realm", function inRealm() {
+			if (!supportsShadowRoot()) {
+				this.skip();
+				return;
+			}
+
+			run(document);
+		});
+	});
+
+	describe('"composed" option defaults to false', function testComposed() {
+		function run(document) {
+			var elems = createShadowRoot(document);
+			proclaim.deepStrictEqual(
+				elems.node.getRootNode(),
+				elems.node.getRootNode({ composed: false })
+			);
+		}
+
+		it("current realm", function inRealm() {
+			if (!supportsShadowRoot()) {
+				this.skip();
+				return;
+			}
+
+			run(document);
+		});
+	});
+});
+
+describe('on the document', function () {
+	it("is a function", function() {
+		proclaim.isFunction(document.getRootNode);
+	});
+
+	it("has correct arity", function() {
+		proclaim.arity(document.getRootNode, 0);
+	});
+
+	it("has correct name", function() {
+		proclaim.hasName(document.getRootNode, "getRootNode");
+	});
+
+	it("returns itself", function() {
+		proclaim.equal(document.getRootNode(), document);
+	});
+});

--- a/polyfills/Node/prototype/isConnected/config.toml
+++ b/polyfills/Node/prototype/isConnected/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = ["Node.prototype.getRootNode"]
+
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected"
+spec = "https://dom.spec.whatwg.org/#dom-node-isconnected"
+
+[browsers]
+android = "<6"
+bb = "*"
+chrome = "<51"
+edge = "*"
+edge_mob = "*"
+firefox = "<49"
+firefox_mob = "<49"
+ie = "*"
+ie_mob = "*"
+opera = "<38"
+op_mob = "<41"
+op_mini = "*"
+safari = "<10"
+ios_saf = "<10"
+samsung_mob = "<6"

--- a/polyfills/Node/prototype/isConnected/detect.js
+++ b/polyfills/Node/prototype/isConnected/detect.js
@@ -1,0 +1,1 @@
+'isConnected' in document

--- a/polyfills/Node/prototype/isConnected/polyfill.js
+++ b/polyfills/Node/prototype/isConnected/polyfill.js
@@ -1,0 +1,34 @@
+(function() {
+	'use strict';
+
+	/**
+	 * An element is connected if its shadow-including root is a document.
+	 */
+	function isConnected() {
+		var root = this.getRootNode({ composed: true });
+		return root.nodeType === 9; // Node.DOCUMENT_NODE
+	}
+
+	function defineIsConnected(object) {
+		Object.defineProperty(object, 'isConnected', {
+			configurable: true,
+			enumerable: true,
+			get: isConnected
+		});
+	}
+
+	// IE
+	if ('HTMLElement' in self && 'isConnected' in HTMLElement.prototype) {
+		try {
+			delete HTMLElement.prototype.isConnected;
+			// eslint-disable-next-line no-empty
+		} catch (e) {}
+	}
+
+	if ('Node' in self) {
+		defineIsConnected(Node.prototype);
+	} else {
+		defineIsConnected(document);
+		defineIsConnected(Element.prototype);
+	}
+}());

--- a/polyfills/Node/prototype/isConnected/tests.js
+++ b/polyfills/Node/prototype/isConnected/tests.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+/* globals proclaim */
+
+describe('on an element', function () {
+	var element = document.createElement('div');
+
+	it('is enumerable', function () {
+		proclaim.isTrue('isConnected' in element);
+	});
+
+	it('is false if node is not connected to a document', function() {
+		proclaim.isFalse(element.isConnected);
+	});
+
+	it('is true if node is connected to a document', function() {
+		document.body.appendChild(element);
+		proclaim.isTrue(element.isConnected);
+	});
+});
+
+describe('on the document', function () {
+	it('is enumerable', function () {
+		proclaim.isTrue('isConnected' in document);
+	});
+
+	it('is true for a document', function() {
+		proclaim.isTrue(document.isConnected);
+	});
+});


### PR DESCRIPTION
This PR adds polyfills for `Node.prototype.getRootNode` and `Node.prototype.isConnected`. It is based on https://github.com/Financial-Times/polyfill-library/pull/485 and https://github.com/Financial-Times/polyfill-library/pull/486.

Resolves https://github.com/Financial-Times/polyfill-library/issues/326.