### PR TITLE
Adds `CharacterData.prototype` polyfills

### DIFF
--- a/polyfills/CharacterData/prototype/after/config.toml
+++ b/polyfills/CharacterData/prototype/after/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = [ "Element.prototype.after" ]
+
+spec = "https://dom.spec.whatwg.org/#dom-childnode-after"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/after"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<54"
+edge = "<17"
+edge_mob = "<17"
+firefox = "<49"
+firefox_mob = "<49"
+ie = "*"
+ie_mob = "*"
+opera = "<39"
+op_mob = "<41"
+op_mini = "*"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<6.0"

--- a/polyfills/CharacterData/prototype/after/detect.js
+++ b/polyfills/CharacterData/prototype/after/detect.js
@@ -1,0 +1,1 @@
+'after' in CharacterData.prototype

--- a/polyfills/CharacterData/prototype/after/polyfill.js
+++ b/polyfills/CharacterData/prototype/after/polyfill.js
@@ -1,0 +1,1 @@
+CharacterData.prototype.after = Element.prototype.after

--- a/polyfills/CharacterData/prototype/before/config.toml
+++ b/polyfills/CharacterData/prototype/before/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = [ "Element.prototype.before" ]
+
+spec = "https://dom.spec.whatwg.org/#dom-childnode-before"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/before"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<54"
+edge = "<17"
+edge_mob = "<17"
+firefox = "<49"
+firefox_mob = "<49"
+ie = "*"
+ie_mob = "*"
+opera = "<39"
+op_mob = "<41"
+op_mini = "*"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<6.0"

--- a/polyfills/CharacterData/prototype/before/detect.js
+++ b/polyfills/CharacterData/prototype/before/detect.js
@@ -1,0 +1,1 @@
+'before' in CharacterData.prototype

--- a/polyfills/CharacterData/prototype/before/polyfill.js
+++ b/polyfills/CharacterData/prototype/before/polyfill.js
@@ -1,0 +1,1 @@
+CharacterData.prototype.before = Element.prototype.before

--- a/polyfills/CharacterData/prototype/nextElementSibling/config.toml
+++ b/polyfills/CharacterData/prototype/nextElementSibling/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = [ "Object.getOwnPropertyDescriptor" ]
+
+spec = "https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/nextElementSibling"
+
+[browsers]
+android = "<4.4"
+bb = "*"
+chrome = "<29"
+edge = "<17"
+edge_mob = "<17"
+firefox = "<25"
+firefox_mob = "<25"
+ie = "*"
+ie_mob = "*"
+opera = "<16"
+op_mob = "<16"
+op_mini = "*"
+safari = "<9.0"
+ios_saf = "<9.0"
+samsung_mob = "<2.0"

--- a/polyfills/CharacterData/prototype/nextElementSibling/detect.js
+++ b/polyfills/CharacterData/prototype/nextElementSibling/detect.js
@@ -1,0 +1,1 @@
+'nextElementSibling' in CharacterData.prototype

--- a/polyfills/CharacterData/prototype/nextElementSibling/polyfill.js
+++ b/polyfills/CharacterData/prototype/nextElementSibling/polyfill.js
@@ -1,0 +1,3 @@
+Object.defineProperty(CharacterData.prototype, 'nextElementSibling',
+	Object.getOwnPropertyDescriptor(Element.prototype, 'nextElementSibling')
+);

--- a/polyfills/CharacterData/prototype/previousElementSibling/config.toml
+++ b/polyfills/CharacterData/prototype/previousElementSibling/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = [ "Object.getOwnPropertyDescriptor" ]
+
+spec = "https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/previousElementSibling"
+
+[browsers]
+android = "<4.4"
+bb = "*"
+chrome = "<29"
+edge = "<17"
+edge_mob = "<17"
+firefox = "<25"
+firefox_mob = "<25"
+ie = "*"
+ie_mob = "*"
+opera = "<16"
+op_mob = "<16"
+op_mini = "*"
+safari = "<9.0"
+ios_saf = "<9.0"
+samsung_mob = "<2.0"

--- a/polyfills/CharacterData/prototype/previousElementSibling/detect.js
+++ b/polyfills/CharacterData/prototype/previousElementSibling/detect.js
@@ -1,0 +1,1 @@
+'previousElementSibling' in CharacterData.prototype

--- a/polyfills/CharacterData/prototype/previousElementSibling/polyfill.js
+++ b/polyfills/CharacterData/prototype/previousElementSibling/polyfill.js
@@ -1,0 +1,3 @@
+Object.defineProperty(CharacterData.prototype, 'previousElementSibling',
+	Object.getOwnPropertyDescriptor(Element.prototype, 'previousElementSibling')
+);

--- a/polyfills/CharacterData/prototype/remove/config.toml
+++ b/polyfills/CharacterData/prototype/remove/config.toml
@@ -1,0 +1,20 @@
+aliases = []
+dependencies = [ "Element.prototype.remove" ]
+
+spec = "https://dom.spec.whatwg.org/#dom-childnode-remove"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/remove"
+
+[browsers]
+android = "<4.4"
+bb = "*"
+chrome = "<24"
+firefox = "<23"
+firefox_mob = "<23"
+ie = "*"
+ie_mob = "*"
+opera = "<15"
+op_mob = "<14"
+op_mini = "*"
+safari = "<7.0"
+ios_saf = "<7.0"
+samsung_mob = "<1.5"

--- a/polyfills/CharacterData/prototype/remove/detect.js
+++ b/polyfills/CharacterData/prototype/remove/detect.js
@@ -1,0 +1,1 @@
+'remove' in CharacterData.prototype

--- a/polyfills/CharacterData/prototype/remove/polyfill.js
+++ b/polyfills/CharacterData/prototype/remove/polyfill.js
@@ -1,0 +1,1 @@
+CharacterData.prototype.remove = Element.prototype.remove

--- a/polyfills/CharacterData/prototype/replaceWith/config.toml
+++ b/polyfills/CharacterData/prototype/replaceWith/config.toml
@@ -1,0 +1,22 @@
+aliases = []
+dependencies = [ "Element.prototype.replaceWith" ]
+
+spec = "https://dom.spec.whatwg.org/#dom-childnode-replacewith"
+docs = "https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/replaceWith"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<54"
+edge = "<17"
+edge_mob = "<17"
+firefox = "<49"
+firefox_mob = "<49"
+ie = "*"
+ie_mob = "*"
+opera = "<39"
+op_mob = "<41"
+op_mini = "*"
+safari = "<10.0"
+ios_saf = "<10.0"
+samsung_mob = "<6.0"

--- a/polyfills/CharacterData/prototype/replaceWith/detect.js
+++ b/polyfills/CharacterData/prototype/replaceWith/detect.js
@@ -1,0 +1,1 @@
+'replaceWith' in CharacterData.prototype

--- a/polyfills/CharacterData/prototype/replaceWith/polyfill.js
+++ b/polyfills/CharacterData/prototype/replaceWith/polyfill.js
@@ -1,0 +1,1 @@
+CharacterData.prototype.replaceWith = Element.prototype.replaceWith


### PR DESCRIPTION
This PR adds polyfills for `CharacterData.prototype`:
* `after`
* `before`
* `nextElementSibling`
* `previousElementSibling`
* `remove`
* `replaceWith`

This list includes all properties of `CharacterData.prototype` that may be missing from the browsers we target, based on https://developer.mozilla.org/en-US/docs/Web/API/CharacterData#browser_compatibility.

Resolves https://github.com/Financial-Times/polyfill-library/issues/214.