### PR TITLE
update ListFormat/config.toml

### DIFF
--- a/polyfills/Intl/ListFormat/config.toml
+++ b/polyfills/Intl/ListFormat/config.toml
@@ -12,7 +12,7 @@ repo = "https://github.com/formatjs/formatjs/tree/master/packages/intl-listforma
 docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/listformat"
 notes = [
 	"Locales must be specified separately by prefixing the locale name with `Intl.ListFormat.~locale`, eg `Intl.ListFormat.~locale.en-GB`.",
-	"Safari version can be set to the first version that isn't installable on macOS Catalina. At this time there is no such version."
+	"Safari 16 is the first version that isn't installable on macOS Catalina. macOS Catalina and older do not include OS level dependencies for this feature"
 ]
 
 [browsers]
@@ -26,7 +26,7 @@ ie = ">=9"
 ie_mob = ">=9"
 opera = "<60"
 op_mob = "<51"
-safari = "*"
+safari = "<16.0"
 ios_saf = "<14.5"
 samsung_mob = "<11.0"
 


### PR DESCRIPTION
Safari 16 was released and is not installable on macOS Catalina : 
https://webkit.org/blog/13152/webkit-features-in-safari-16-0/