### PR TITLE
Adds `findLast` and `findLastIndex` polyfills

### DIFF
--- a/polyfills/Array/prototype/findLast/config.toml
+++ b/polyfills/Array/prototype/findLast/config.toml
@@ -1,0 +1,30 @@
+aliases = [ "es2023" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.Get",
+	"_ESAbstract.IsCallable",
+	"_ESAbstract.LengthOfArrayLike",
+	"_ESAbstract.ToBoolean",
+	"_ESAbstract.ToObject",
+	"_ESAbstract.ToString",
+]
+spec = "https://tc39.es/ecma262/#sec-array.prototype.findlast"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<97"
+edge = "*"
+edge_mob = "*"
+firefox = "<104"
+firefox_mob = "<104"
+ie = "*"
+ie_mob = "*"
+opera = "<83"
+op_mob = "<68"
+op_mini = "*"
+safari = "<15.4"
+ios_saf = "<15.4"
+samsung_mob = "<18.0"

--- a/polyfills/Array/prototype/findLast/detect.js
+++ b/polyfills/Array/prototype/findLast/detect.js
@@ -1,0 +1,1 @@
+'findLast' in Array.prototype

--- a/polyfills/Array/prototype/findLast/polyfill.js
+++ b/polyfills/Array/prototype/findLast/polyfill.js
@@ -1,0 +1,29 @@
+/* global Call, CreateMethodProperty, Get, IsCallable, LengthOfArrayLike, ToBoolean, ToObject, ToString */
+// 23.1.3.11 Array.prototype.findLast ( predicate [ , thisArg ] )
+CreateMethodProperty(Array.prototype, 'findLast', function findLast(predicate /*[ , thisArg ]*/) {
+	// 1. Let O be ? ToObject(this value).
+	var O = ToObject(this);
+	// 2. Let len be ? LengthOfArrayLike(O).
+	var len = LengthOfArrayLike(O);
+	// 3. If IsCallable(predicate) is false, throw a TypeError exception.
+	if (!IsCallable(predicate)) throw TypeError();
+	// 4. Let k be len - 1.
+	var k = len - 1;
+	// 5. Repeat, while k ≥ 0,
+	while (k >= 0) {
+		// a. Let Pk be ! ToString(𝔽(k)).
+		var Pk = ToString(k);
+		// b. Let kValue be ? Get(O, Pk).
+		var kValue = Get(O, Pk);
+		// c. Let testResult be ToBoolean(? Call(predicate, thisArg, « kValue, 𝔽(k), O »)).
+		var testResult = ToBoolean(Call(predicate, arguments.length > 1 ? arguments[1] : undefined, [kValue, k, O]))
+		// d. If testResult is true, return kValue.
+		if (testResult) {
+			return kValue;
+		}
+		// e. Set k to k - 1.
+		k = k - 1;
+	}
+	// 6. Return undefined.
+	return undefined;
+});

--- a/polyfills/Array/prototype/findLast/tests.js
+++ b/polyfills/Array/prototype/findLast/tests.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+it('is a function', function () {
+	proclaim.isFunction(Array.prototype.findLast);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Array.prototype.findLast, 1);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Array.prototype.findLast, 'findLast');
+});
+
+it('is not enumerable', function () {
+	proclaim.isNotEnumerable(Array.prototype, 'findLast');
+});
+
+describe('findLast', function () {
+	function isOdd (v) {
+		return v % 2 === 1;
+	}
+
+	function hasOddIndex (_v, i) {
+		return isOdd(i)
+	}
+
+	function matchesThisX (v) {
+		return v === this.x
+	}
+
+	function matchesMyLength (v, _i, self) {
+		return v === self.length;
+	}
+
+	it('should throw when `predicate` is not callable', function () {
+		proclaim.throws(function () {
+			[].findLast(null);
+		}, TypeError);
+	});
+
+	[
+		{ kind: 'array', thing: [3, 4, 5, 6] },
+		{ kind: 'array-like object', thing: {0: 3, 1: 4, 2: 5, 3: 6, length: 4} }
+	].forEach(function (test) {
+		describe(test.kind, function () {
+			var thing = test.thing;
+
+			it('should retrieve the last matching item', function () {
+				proclaim.equal(Array.prototype.findLast.call(thing, isOdd), 5);
+				proclaim.equal(Array.prototype.findLast.call(thing, hasOddIndex), 6);
+				proclaim.equal(Array.prototype.findLast.call(thing, matchesThisX), undefined);
+				proclaim.equal(Array.prototype.findLast.call(thing, matchesMyLength), 4);
+			});
+
+			it('should retrieve the last matching item with `thisArg`', function () {
+				proclaim.equal(Array.prototype.findLast.call(thing, matchesThisX, { x: 4 }), 4);
+			});
+		});
+	});
+});

--- a/polyfills/Array/prototype/findLastIndex/config.toml
+++ b/polyfills/Array/prototype/findLastIndex/config.toml
@@ -1,0 +1,30 @@
+aliases = [ "es2023" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.Get",
+	"_ESAbstract.IsCallable",
+	"_ESAbstract.LengthOfArrayLike",
+	"_ESAbstract.ToBoolean",
+	"_ESAbstract.ToObject",
+	"_ESAbstract.ToString",
+]
+spec = "https://tc39.es/ecma262/#sec-array.prototype.findlastindex"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<97"
+edge = "*"
+edge_mob = "*"
+firefox = "<104"
+firefox_mob = "<104"
+ie = "*"
+ie_mob = "*"
+opera = "<83"
+op_mob = "<68"
+op_mini = "*"
+safari = "<15.4"
+ios_saf = "<15.4"
+samsung_mob = "<18.0"

--- a/polyfills/Array/prototype/findLastIndex/detect.js
+++ b/polyfills/Array/prototype/findLastIndex/detect.js
@@ -1,0 +1,1 @@
+'findLastIndex' in Array.prototype

--- a/polyfills/Array/prototype/findLastIndex/polyfill.js
+++ b/polyfills/Array/prototype/findLastIndex/polyfill.js
@@ -1,0 +1,29 @@
+/* global Call, CreateMethodProperty, Get, IsCallable, LengthOfArrayLike, ToBoolean, ToObject, ToString */
+// 23.1.3.12 Array.prototype.findLastIndex ( predicate [ , thisArg ] )
+CreateMethodProperty(Array.prototype, 'findLastIndex', function findLastIndex(predicate /*[ , thisArg ]*/) {
+	// 1. Let O be ? ToObject(this value).
+	var O = ToObject(this);
+	// 2. Let len be ? LengthOfArrayLike(O).
+	var len = LengthOfArrayLike(O);
+	// 3. If IsCallable(predicate) is false, throw a TypeError exception.
+	if (!IsCallable(predicate)) throw TypeError();
+	// 4. Let k be len - 1.
+	var k = len - 1;
+	// 5. Repeat, while k ≥ 0,
+	while (k >= 0) {
+		// a. Let Pk be ! ToString(𝔽(k)).
+		var Pk = ToString(k);
+		// b. Let kValue be ? Get(O, Pk).
+		var kValue = Get(O, Pk);
+		// c. Let testResult be ToBoolean(? Call(predicate, thisArg, « kValue, 𝔽(k), O »)).
+		var testResult = ToBoolean(Call(predicate, arguments.length > 1 ? arguments[1] : undefined, [kValue, k, O]))
+		// d. If testResult is true, return 𝔽(k).
+		if (testResult) {
+			return k;
+		}
+		// e. Set k to k - 1.
+		k = k - 1;
+	}
+	// 6. Return -1𝔽.
+	return -1;
+});

--- a/polyfills/Array/prototype/findLastIndex/tests.js
+++ b/polyfills/Array/prototype/findLastIndex/tests.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha, browser */
+/* global proclaim */
+
+it('is a function', function () {
+	proclaim.isFunction(Array.prototype.findLastIndex);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Array.prototype.findLastIndex, 1);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Array.prototype.findLastIndex, 'findLastIndex');
+});
+
+it('is not enumerable', function () {
+	proclaim.isNotEnumerable(Array.prototype, 'findLastIndex');
+});
+
+describe('findLastIndex', function () {
+	function isOdd (v) {
+		return v % 2 === 1;
+	}
+
+	function hasOddIndex (_v, i) {
+		return isOdd(i)
+	}
+
+	function matchesThisX (v) {
+		return v === this.x
+	}
+
+	function matchesMyLength (v, _i, self) {
+		return v === self.length;
+	}
+
+	it('should throw when `predicate` is not callable', function () {
+		proclaim.throws(function () {
+			[].findLastIndex(null);
+		}, TypeError);
+	});
+
+	[
+		{ kind: 'array', thing: [3, 4, 5, 6] },
+		{ kind: 'array-like object', thing: {0: 3, 1: 4, 2: 5, 3: 6, length: 4} }
+	].forEach(function (test) {
+		describe(test.kind, function () {
+			var thing = test.thing;
+
+			it('should retrieve the last matching item', function () {
+				proclaim.equal(Array.prototype.findLastIndex.call(thing, isOdd), 2);
+				proclaim.equal(Array.prototype.findLastIndex.call(thing, hasOddIndex), 3);
+				proclaim.equal(Array.prototype.findLastIndex.call(thing, matchesThisX), -1);
+				proclaim.equal(Array.prototype.findLastIndex.call(thing, matchesMyLength), 1);
+			});
+
+			it('should retrieve the last matching item with `thisArg`', function () {
+				proclaim.equal(Array.prototype.findLastIndex.call(thing, matchesThisX, { x: 4 }), 1);
+			});
+		});
+	});
+});

--- a/polyfills/TypedArray/prototype/findLast/config.toml
+++ b/polyfills/TypedArray/prototype/findLast/config.toml
@@ -1,0 +1,29 @@
+aliases = [ "es2023" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.Get",
+	"_ESAbstract.IsCallable",
+	"_ESAbstract.ToBoolean",
+	"_ESAbstract.ToString",
+	"ArrayBuffer",
+]
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlast"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLast"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<97"
+edge = "*"
+edge_mob = "*"
+firefox = "<104"
+firefox_mob = "<104"
+ie = "*"
+ie_mob = "*"
+opera = "<83"
+op_mob = "<68"
+op_mini = "*"
+safari = "<15.4"
+ios_saf = "<15.4"
+samsung_mob = "<18.0"

--- a/polyfills/TypedArray/prototype/findLast/detect.js
+++ b/polyfills/TypedArray/prototype/findLast/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'findLast' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/findLast/polyfill.js
+++ b/polyfills/TypedArray/prototype/findLast/polyfill.js
@@ -1,0 +1,50 @@
+/* global Call, CreateMethodProperty, Get, IsCallable, ToBoolean, ToString */
+// 23.2.3.13 %TypedArray%.prototype.findLast ( predicate [ , thisArg ] )
+(function () {
+	function findLast(predicate /*[ , thisArg ]*/) {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? ValidateTypedArray(O).
+		// TODO: Add ValidateTypedArray
+		// 3. Let len be O.[[ArrayLength]].
+		var len = O.length;
+		// 4. If IsCallable(predicate) is false, throw a TypeError exception.
+		if (!IsCallable(predicate)) throw TypeError();
+		// 5. Let k be len - 1.
+		var k = len - 1;
+		// 6. Repeat, while k ≥ 0,
+		while (k >= 0) {
+			// a. Let Pk be ! ToString(𝔽(k)).
+			var Pk = ToString(k);
+			// b. Let kValue be ! Get(O, Pk).
+			var kValue = Get(O, Pk);
+			// c. Let testResult be ToBoolean(? Call(predicate, thisArg, « kValue, 𝔽(k), O »)).
+			var testResult = ToBoolean(Call(predicate, arguments.length > 1 ? arguments[1] : undefined, [kValue, k, O]))
+			// d. If testResult is true, return kValue.
+			if (testResult) {
+				return kValue;
+			}
+			// e. Set k to k - 1.
+			k = k - 1;
+		}
+		// 7. Return undefined.
+		return undefined;
+	}
+
+	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+	// in that case, don't define `at` on the parent; define it directly on the prototype
+	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, 'findLast', findLast);
+	} else {
+		CreateMethodProperty(self.Int8Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Uint8Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Int16Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Uint16Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Int32Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Uint32Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Float32Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Float64Array.prototype, 'findLast', findLast);
+	}
+})();

--- a/polyfills/TypedArray/prototype/findLast/tests.js
+++ b/polyfills/TypedArray/prototype/findLast/tests.js
@@ -1,0 +1,61 @@
+/* eslint-env mocha, browser */
+/* global proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is a function', function () {
+	proclaim.isFunction(Int8Array.prototype.findLast);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Int8Array.prototype.findLast, 1);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Int8Array.prototype.findLast, 'findLast');
+});
+
+it('is not enumerable', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isNotEnumerable(Int8Array.prototype.__proto__, 'findLast');
+	} else {
+		proclaim.isNotEnumerable(Int8Array.prototype, 'findLast');
+	}
+});
+
+describe('findLast', function () {
+	function isOdd (v) {
+		return v % 2 === 1;
+	}
+
+	function hasOddIndex (_v, i) {
+		return isOdd(i)
+	}
+
+	function matchesThisX (v) {
+		return v === this.x
+	}
+
+	function matchesMyLength (v, _i, self) {
+		return v === self.length;
+	}
+
+	it('should throw when `predicate` is not callable', function () {
+		proclaim.throws(function () {
+			new Int8Array().findLast(null);
+		}, TypeError);
+	});
+
+	var arr = new Int8Array([3, 4, 5, 6])
+
+	it('should retrieve the last matching element', function () {
+		proclaim.equal(arr.findLast(isOdd), 5);
+		proclaim.equal(arr.findLast(hasOddIndex), 6);
+		proclaim.equal(arr.findLast(matchesThisX), undefined);
+		proclaim.equal(arr.findLast(matchesMyLength), 4);
+	});
+
+	it('should retrieve the last matching item with `thisArg`', function () {
+		proclaim.equal(arr.findLast(matchesThisX, { x: 4 }), 4);
+	});
+});

--- a/polyfills/TypedArray/prototype/findLastIndex/config.toml
+++ b/polyfills/TypedArray/prototype/findLastIndex/config.toml
@@ -1,0 +1,29 @@
+aliases = [ "es2023" ]
+dependencies = [
+	"_ESAbstract.Call",
+	"_ESAbstract.CreateMethodProperty",
+	"_ESAbstract.Get",
+	"_ESAbstract.IsCallable",
+	"_ESAbstract.ToBoolean",
+	"_ESAbstract.ToString",
+	"ArrayBuffer",
+]
+spec = "https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlastindex"
+docs = "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLastIndex"
+
+[browsers]
+android = "*"
+bb = "*"
+chrome = "<97"
+edge = "*"
+edge_mob = "*"
+firefox = "<104"
+firefox_mob = "<104"
+ie = "*"
+ie_mob = "*"
+opera = "<83"
+op_mob = "<68"
+op_mini = "*"
+safari = "<15.4"
+ios_saf = "<15.4"
+samsung_mob = "<18.0"

--- a/polyfills/TypedArray/prototype/findLastIndex/detect.js
+++ b/polyfills/TypedArray/prototype/findLastIndex/detect.js
@@ -1,0 +1,2 @@
+// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+'Int8Array' in self && 'findLastIndex' in self.Int8Array.prototype

--- a/polyfills/TypedArray/prototype/findLastIndex/polyfill.js
+++ b/polyfills/TypedArray/prototype/findLastIndex/polyfill.js
@@ -1,0 +1,50 @@
+/* global Call, CreateMethodProperty, Get, IsCallable, ToBoolean, ToString */
+// 23.2.3.14 %TypedArray%.prototype.findLastIndex ( predicate [ , thisArg ] )
+(function () {
+	function findLastIndex(predicate /*[ , thisArg ]*/) {
+		// 1. Let O be the this value.
+		var O = this;
+		// 2. Perform ? ValidateTypedArray(O).
+		// TODO: Add ValidateTypedArray
+		// 3. Let len be O.[[ArrayLength]].
+		var len = O.length;
+		// 4. If IsCallable(predicate) is false, throw a TypeError exception.
+		if (!IsCallable(predicate)) throw TypeError();
+		// 5. Let k be len - 1.
+		var k = len - 1;
+		// 6. Repeat, while k ≥ 0,
+		while (k >= 0) {
+			// a. Let Pk be ! ToString(𝔽(k)).
+			var Pk = ToString(k);
+			// b. Let kValue be ! Get(O, Pk).
+			var kValue = Get(O, Pk);
+			// c. Let testResult be ToBoolean(? Call(predicate, thisArg, « kValue, 𝔽(k), O »)).
+			var testResult = ToBoolean(Call(predicate, arguments.length > 1 ? arguments[1] : undefined, [kValue, k, O]))
+			// d. If testResult is true, return 𝔽(k).
+			if (testResult) {
+				return k;
+			}
+			// e. Set k to k - 1.
+			k = k - 1;
+		}
+		// 7. Return -1𝔽.
+		return -1;
+	}
+
+	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+	// in that case, don't define `at` on the parent; define it directly on the prototype
+	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, 'findLastIndex', findLastIndex);
+	} else {
+		CreateMethodProperty(self.Int8Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Uint8Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Int16Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Uint16Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Int32Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Uint32Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Float32Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Float64Array.prototype, 'findLastIndex', findLastIndex);
+	}
+})();

--- a/polyfills/TypedArray/prototype/findLastIndex/tests.js
+++ b/polyfills/TypedArray/prototype/findLastIndex/tests.js
@@ -1,0 +1,61 @@
+/* eslint-env mocha, browser */
+/* global proclaim, Int8Array */
+
+// use "Int8Array" as a proxy for all "TypedArray" subclasses
+
+it('is a function', function () {
+	proclaim.isFunction(Int8Array.prototype.findLastIndex);
+});
+
+it('has correct arity', function () {
+	proclaim.arity(Int8Array.prototype.findLastIndex, 1);
+});
+
+it('has correct name', function () {
+	proclaim.hasName(Int8Array.prototype.findLastIndex, 'findLastIndex');
+});
+
+it('is not enumerable', function () {
+	if ('__proto__' in Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		proclaim.isNotEnumerable(Int8Array.prototype.__proto__, 'findLastIndex');
+	} else {
+		proclaim.isNotEnumerable(Int8Array.prototype, 'findLastIndex');
+	}
+});
+
+describe('findLastIndex', function () {
+	function isOdd (v) {
+		return v % 2 === 1;
+	}
+
+	function hasOddIndex (_v, i) {
+		return isOdd(i)
+	}
+
+	function matchesThisX (v) {
+		return v === this.x
+	}
+
+	function matchesMyLength (v, _i, self) {
+		return v === self.length;
+	}
+
+	it('should throw when `predicate` is not callable', function () {
+		proclaim.throws(function () {
+			new Int8Array().findLastIndex(null);
+		}, TypeError);
+	});
+
+	var arr = new Int8Array([3, 4, 5, 6])
+
+	it('should retrieve the last matching element', function () {
+		proclaim.equal(arr.findLastIndex(isOdd), 2);
+		proclaim.equal(arr.findLastIndex(hasOddIndex), 3);
+		proclaim.equal(arr.findLastIndex(matchesThisX), -1);
+		proclaim.equal(arr.findLastIndex(matchesMyLength), 1);
+	});
+
+	it('should retrieve the last matching item with `thisArg`', function () {
+		proclaim.equal(arr.findLastIndex(matchesThisX, { x: 4 }), 1);
+	});
+});


### PR DESCRIPTION
This PR adds the following ES2023 polyfills:

* `Array.prototype.findLast`
* `Array.prototype.findLastIndex`
* `%TypedArray%.prototype.findLast`
* `%TypedArray%.prototype.findLastIndex`