### PR TITLE
Fixes `Error` prototype in `_InstallErrorCause`

### DIFF
--- a/polyfills/Error/cause/tests.js
+++ b/polyfills/Error/cause/tests.js
@@ -50,6 +50,10 @@ testCases.forEach(function (testCase) {
 		});
 
 		if (name !== 'AggregateError') {
+			it('is instance of Error', function () {
+				proclaim.isInstanceOf(new _Error('m'), Error);
+			})
+
 			it('creates an object without a cause', function () {
 				proclaim.equal(new _Error('m').name, name);
 				proclaim.equal(new _Error('m').message, 'm');
@@ -70,6 +74,10 @@ testCases.forEach(function (testCase) {
 				proclaim.isObject(_Error());
 			});
 		} else {
+			it('is instance of Error', function () {
+				proclaim.isInstanceOf(new _Error([], 'm'), Error);
+			})
+
 			it('creates an object without a cause', function () {
 				proclaim.equal(new _Error([], 'm').name, name);
 				proclaim.deepEqual(new _Error([], 'm').errors, []);

--- a/polyfills/_InstallErrorCause/polyfill.js
+++ b/polyfills/_InstallErrorCause/polyfill.js
@@ -37,6 +37,10 @@ var _GetErrorConstructorWithCauseInstalled;
 		}
 		_Error.prototype = _nativeErrors[name].prototype;
 		Object.defineProperty(_Error, 'prototype', { writable: false });
+		// in IE11, the constructor name needs to be corrected
+		if (_Error.name !== name) {
+			Object.defineProperty(_Error, 'name', { value: name, configurable: true });
+		}
 		return _Error;
 	}
 

--- a/polyfills/_InstallErrorCause/polyfill.js
+++ b/polyfills/_InstallErrorCause/polyfill.js
@@ -32,7 +32,9 @@ var _GetErrorConstructorWithCauseInstalled;
 
 	// based on https://github.com/es-shims/error-cause/blob/de17ea05/Error/implementation.js#L22-L29
 	function _inheritErrorPrototype (name, _Error) {
-		Object.setPrototypeOf(_Error, self.Error);
+		if (name !== 'Error') {
+			Object.setPrototypeOf(_Error, self.Error);
+		}
 		_Error.prototype = _nativeErrors[name].prototype;
 		Object.defineProperty(_Error, 'prototype', { writable: false });
 		return _Error;
@@ -55,9 +57,7 @@ var _GetErrorConstructorWithCauseInstalled;
 	_GetErrorConstructorWithCauseInstalled = function (name) {
 		_nativeErrors[name] = self[name];
 		_errorConstructors[name] = _makeErrorConstructor(name, _newErrors[name]);
-		if (name !== 'Error') {
-			_inheritErrorPrototype(name, _newErrors[name]);
-		}
+		_inheritErrorPrototype(name, _newErrors[name]);
 		return _newErrors[name];
 	}
 })();


### PR DESCRIPTION
This PR fixes an `Error` prototype issue in `_InstallErrorCause`, which was identified in https://github.com/Financial-Times/polyfill-library/pull/1257.

See https://github.com/Financial-Times/polyfill-library/actions/runs/3869344912/jobs/6595380297 for the `polyfillCombinations` test failure.