### PR TITLE
backstage: only checkout approved commits when running tests

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Fork based /ok-to-test checkout
         uses: actions/checkout@v2
         with:
-          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+          ref: ${{ github.event.client_payload.slash_command.sha }}
           fetch-depth: 50
 
       # Fetch master branch to determine which polyfills have changed and need testing.


### PR DESCRIPTION
A comment `/ok-to-test` on fork-based pull requests runs tests.

In the test action we check to see if the pull request head matches the commit which was ok'ed with a comment:
https://github.com/Financial-Times/polyfill-library/blob/28f938fa6fbf537b97ee0492a68b47358c6301ba/.github/workflows/test-polyfills.yml#L69

If that is the case we checkout the PR head by PR number: https://github.com/Financial-Times/polyfill-library/blob/28f938fa6fbf537b97ee0492a68b47358c6301ba/.github/workflows/test-polyfills.yml#L80

In theory, there's a very small window between Github deciding to run an action and checking out the code where a malicious actor could push unauthorised code. To avoid this we can checkout code using `${{ github.event.client_payload.slash_command.sha }}` instead of
`refs/pull/${{ github.event.client_payload.pull_request.number }}/merge`