### PR TITLE
Streamline TypedArray polyfills

### DIFF
--- a/polyfills/TypedArray/prototype/entries/polyfill.js
+++ b/polyfills/TypedArray/prototype/entries/polyfill.js
@@ -1,30 +1,7 @@
 /* global CreateMethodProperty, ArrayIterator */
 // 23.2.3.7 %TypedArray%.prototype.entries ( )
 (function () {
-	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
-
-	function createMethodProperties (fn) {
-		var fnName = 'entries'
-
-		// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
-		// in that case, don't define it on the parent; define it directly on the prototype
-		if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
-			// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
-			CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, fn);
-		} else {
-			CreateMethodProperty(self.Int8Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint8Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, fn);
-			CreateMethodProperty(self.Int16Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint16Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Int32Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint32Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Float32Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Float64Array.prototype, fnName, fn);
-		}
-	}
-
-	createMethodProperties(function entries () {
+	function entries() {
 		// 1. Let O be the this value.
 		var O = this;
 		// 2. Perform ? ValidateTypedArray(O).
@@ -32,5 +9,24 @@
 		// 3. Return CreateArrayIterator(O, key).
 		// TODO: Add CreateArrayIterator
 		return new ArrayIterator(O, 'key+value');
-	});
+	}
+
+	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+	var fnName = 'entries'
+	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+	// in that case, don't define it on the parent; define it directly on the prototype
+	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, entries);
+	} else {
+		CreateMethodProperty(self.Int8Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Uint8Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, entries);
+		CreateMethodProperty(self.Int16Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Uint16Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Int32Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Uint32Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Float32Array.prototype, fnName, entries);
+		CreateMethodProperty(self.Float64Array.prototype, fnName, entries);
+	}
 })();

--- a/polyfills/TypedArray/prototype/findLast/polyfill.js
+++ b/polyfills/TypedArray/prototype/findLast/polyfill.js
@@ -31,20 +31,21 @@
 		return undefined;
 	}
 
+	var fnName = 'findLast'
 	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
 	// in that case, don't define it on the parent; define it directly on the prototype
 	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
 		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
-		CreateMethodProperty(self.Int8Array.prototype.__proto__, 'findLast', findLast);
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, findLast);
 	} else {
-		CreateMethodProperty(self.Int8Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Uint8Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Uint8ClampedArray.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Int16Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Uint16Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Int32Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Uint32Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Float32Array.prototype, 'findLast', findLast);
-		CreateMethodProperty(self.Float64Array.prototype, 'findLast', findLast);
+		CreateMethodProperty(self.Int8Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Uint8Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, findLast);
+		CreateMethodProperty(self.Int16Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Uint16Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Int32Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Uint32Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Float32Array.prototype, fnName, findLast);
+		CreateMethodProperty(self.Float64Array.prototype, fnName, findLast);
 	}
 })();

--- a/polyfills/TypedArray/prototype/findLastIndex/polyfill.js
+++ b/polyfills/TypedArray/prototype/findLastIndex/polyfill.js
@@ -31,20 +31,21 @@
 		return -1;
 	}
 
+	var fnName = 'findLastIndex'
 	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
 	// in that case, don't define it on the parent; define it directly on the prototype
 	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
 		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
-		CreateMethodProperty(self.Int8Array.prototype.__proto__, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, findLastIndex);
 	} else {
-		CreateMethodProperty(self.Int8Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Uint8Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Uint8ClampedArray.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Int16Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Uint16Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Int32Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Uint32Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Float32Array.prototype, 'findLastIndex', findLastIndex);
-		CreateMethodProperty(self.Float64Array.prototype, 'findLastIndex', findLastIndex);
+		CreateMethodProperty(self.Int8Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Uint8Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Int16Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Uint16Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Int32Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Uint32Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Float32Array.prototype, fnName, findLastIndex);
+		CreateMethodProperty(self.Float64Array.prototype, fnName, findLastIndex);
 	}
 })();

--- a/polyfills/TypedArray/prototype/keys/polyfill.js
+++ b/polyfills/TypedArray/prototype/keys/polyfill.js
@@ -1,30 +1,7 @@
 /* global CreateMethodProperty, ArrayIterator */
 // 23.2.3.19 %TypedArray%.prototype.keys ( )
 (function () {
-	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
-
-	function createMethodProperties (fn) {
-		var fnName = 'keys'
-
-		// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
-		// in that case, don't define it on the parent; define it directly on the prototype
-		if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
-			// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
-			CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, fn);
-		} else {
-			CreateMethodProperty(self.Int8Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint8Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, fn);
-			CreateMethodProperty(self.Int16Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint16Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Int32Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Uint32Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Float32Array.prototype, fnName, fn);
-			CreateMethodProperty(self.Float64Array.prototype, fnName, fn);
-		}
-	}
-
-	createMethodProperties(function keys () {
+	function keys() {
 		// 1. Let O be the this value.
 		var O = this;
 		// 2. Perform ? ValidateTypedArray(O).
@@ -32,5 +9,24 @@
 		// 3. Return CreateArrayIterator(O, key).
 		// TODO: Add CreateArrayIterator
 		return new ArrayIterator(O, 'key');
-	});
+	}
+
+	// use "Int8Array" as a proxy for support of "TypedArray" subclasses
+	var fnName = 'keys'
+	// in IE11, `Int8Array.prototype` inherits directly from `Object.prototype`
+	// in that case, don't define it on the parent; define it directly on the prototype
+	if ('__proto__' in self.Int8Array.prototype && self.Int8Array.prototype.__proto__ !== Object.prototype) {
+		// set this on the underlying "TypedArrayPrototype", which is shared with all "TypedArray" subclasses
+		CreateMethodProperty(self.Int8Array.prototype.__proto__, fnName, keys);
+	} else {
+		CreateMethodProperty(self.Int8Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Uint8Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Uint8ClampedArray.prototype, fnName, keys);
+		CreateMethodProperty(self.Int16Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Uint16Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Int32Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Uint32Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Float32Array.prototype, fnName, keys);
+		CreateMethodProperty(self.Float64Array.prototype, fnName, keys);
+	}
 })();


### PR DESCRIPTION
- Use `fnName` variable instead of repeated identical strings, for better minification
- Remove unnecessary `createMethodProperties(fn)` function, in favour of same structure in all different polyfills