### PR TITLE
Revert "backstage: only checkout approved commits when running tests"

### DIFF
--- a/.github/workflows/test-polyfills.yml
+++ b/.github/workflows/test-polyfills.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Fork based /ok-to-test checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.client_payload.slash_command.sha }}
+          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
           fetch-depth: 50
 
       # Fetch master branch to determine which polyfills have changed and need testing.


### PR DESCRIPTION
Reverts Financial-Times/polyfill-library#1264
Closes https://github.com/Financial-Times/polyfill-library/issues/1273