### PR TITLE
`Array.prototype.sort` : extra tests

### DIFF
--- a/polyfills/Array/prototype/sort/tests.js
+++ b/polyfills/Array/prototype/sort/tests.js
@@ -89,12 +89,60 @@ it("sorts arrays with comparefn that returns non-number results", function () {
 	);
 });
 
-it("has a stable sort", function () {
-	var obj = {length:3, 0:2, 1:1,2:3};
+it("has a stable sort with array-like objects", function () {
+	var obj = { length: 3, 0: 2, 1: 1, 2: 3 };
 	proclaim.deepStrictEqual(
 		Array.prototype.sort.call(obj, function (a, b) {
 			return a - b;
 		}),
 		obj
 	);
+
+	proclaim.equal(obj[0], 1);
+	proclaim.equal(obj[1], 2);
+	proclaim.equal(obj[2], 3);
+});
+
+it("has a stable sort with arrays that contain duplicate values", function () {
+	var array = [
+		{ unique: 'a', sortValue: 1 },
+		{ unique: 'b', sortValue: 2 },
+		{ unique: 'c', sortValue: 0 },
+		{ unique: 'd', sortValue: 4 },
+		{ unique: 'e', sortValue: 2 },
+		{ unique: 'f', sortValue: 2 }
+	];
+
+	array.sort(function (a, b) {
+		return a.sortValue - b.sortValue;
+	});
+
+	proclaim.equal(array[0].unique, 'c');
+	proclaim.equal(array[1].unique, 'a');
+	proclaim.equal(array[2].unique, 'b');
+	proclaim.equal(array[3].unique, 'e');
+	proclaim.equal(array[4].unique, 'f');
+	proclaim.equal(array[5].unique, 'd');
+});
+
+it("has a stable sort with arrays that contain duplicate values and comparefn occasionally returns NaN", function () {
+	var array = [
+		{ unique: 'a', sortValue: 1 },
+		{ unique: 'b', sortValue: 2 },
+		{ unique: 'c', sortValue: 0 },
+		{ unique: 'd', sortValue: 4 },
+		{ unique: 'e', sortValue: undefined },
+		{ unique: 'f', sortValue: 2 }
+	];
+
+	array.sort(function (a, b) {
+		return a.sortValue - b.sortValue;
+	});
+
+	proclaim.equal(array[0].unique, 'c');
+	proclaim.equal(array[1].unique, 'a');
+	proclaim.equal(array[2].unique, 'b');
+	proclaim.equal(array[3].unique, 'd');
+	proclaim.equal(array[4].unique, 'e');
+	proclaim.equal(array[5].unique, 'f');
 });

--- a/polyfills/Array/prototype/sort/tests.js
+++ b/polyfills/Array/prototype/sort/tests.js
@@ -117,12 +117,14 @@ it("has a stable sort with arrays that contain duplicate values", function () {
 		return a.sortValue - b.sortValue;
 	});
 
-	proclaim.equal(array[0].unique, 'c');
-	proclaim.equal(array[1].unique, 'a');
-	proclaim.equal(array[2].unique, 'b');
-	proclaim.equal(array[3].unique, 'e');
-	proclaim.equal(array[4].unique, 'f');
-	proclaim.equal(array[5].unique, 'd');
+	proclaim.deepStrictEqual(array, [
+		{ unique: 'c', sortValue: 0 },
+		{ unique: 'a', sortValue: 1 },
+		{ unique: 'b', sortValue: 2 },
+		{ unique: 'e', sortValue: 2 },
+		{ unique: 'f', sortValue: 2 },
+		{ unique: 'd', sortValue: 4 }
+	]);
 });
 
 it("has a stable sort with arrays that contain duplicate values and comparefn occasionally returns NaN", function () {
@@ -139,10 +141,42 @@ it("has a stable sort with arrays that contain duplicate values and comparefn oc
 		return a.sortValue - b.sortValue;
 	});
 
-	proclaim.equal(array[0].unique, 'c');
-	proclaim.equal(array[1].unique, 'a');
-	proclaim.equal(array[2].unique, 'b');
-	proclaim.equal(array[3].unique, 'd');
-	proclaim.equal(array[4].unique, 'e');
-	proclaim.equal(array[5].unique, 'f');
+	proclaim.deepStrictEqual(array, [
+		{ unique: 'c', sortValue: 0 },
+		{ unique: 'a', sortValue: 1 },
+		{ unique: 'b', sortValue: 2 },
+		{ unique: 'd', sortValue: 4 },
+		{ unique: 'e', sortValue: undefined },
+		{ unique: 'f', sortValue: 2 }
+	]);
+});
+
+it("has a stable sort with arrays that contain duplicate values and is sparse", function () {
+	// eslint-disable-next-line no-sparse-arrays
+	var array = [
+		{ unique: 'a', sortValue: 1 },
+		{ unique: 'b', sortValue: 2 },
+		{ unique: 'c', sortValue: 0 },
+		,
+		{ unique: 'd', sortValue: 4 },
+		{ unique: 'e', sortValue: 2 },
+		{ unique: 'f', sortValue: 2 }
+	];
+
+	array.sort(function (a, b) {
+		return a.sortValue - b.sortValue;
+	});
+
+	// eslint-disable-next-line no-sparse-arrays
+	proclaim.deepStrictEqual(array, [
+		{ unique: 'c', sortValue: 0 },
+		{ unique: 'a', sortValue: 1 },
+		{ unique: 'b', sortValue: 2 },
+		{ unique: 'e', sortValue: 2 },
+		{ unique: 'f', sortValue: 2 },
+		{ unique: 'd', sortValue: 4 },
+		,
+	]);
+
+	proclaim.equal(array.length, 7);
 });


### PR DESCRIPTION
Extra tests for `Array.prototype.sort` to ensure that it is really doing a stable sort.

_Initially created to debug a test failure in `Array.prototype.toSorted`_

-----

Original message :

The stable sort polyfill is causing issues for `toSorted`.
Somehow it gives unexpected results with sparse arrays.

I haven't found the issue yet, but these are some extra tests.

@mhassan1 I've been testing on Edge 15 (but 18 should fail aswel) with this url :
http://bs-local.com:9876/test?includePolyfills=yes&always=no&feature=Array.prototype.toSorted&polyfillCombinations=yes

Maybe you spot something I am overlooking :)