### PR TITLE
Fixes `Array.prototype.sort` for sparse arrays

### DIFF
--- a/polyfills/Array/prototype/sort/config.toml
+++ b/polyfills/Array/prototype/sort/config.toml
@@ -2,6 +2,7 @@ aliases = [ "es6", "es2015", "modernizr:es6array" ]
 dependencies = [
 	"_ESAbstract.CreateMethodProperty",
 	"_ESAbstract.IsCallable",
+	"Number.isNaN",
 ]
 license = "MIT"
 spec = "http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.sort"

--- a/polyfills/Array/prototype/sort/polyfill.js
+++ b/polyfills/Array/prototype/sort/polyfill.js
@@ -31,22 +31,32 @@ CreateMethodProperty(Array.prototype, "sort", function sort(compareFn) {
 		// if compareFn exists, sort the array, breaking sorting ties by using the
 		// items' original index position.
 
+		var index;
+
 		// Keep track of the items starting index position.
-		var that = Array.prototype.map.call(this, function(item, index) {
-			return { item: item, index: index };
-		});
+		var that = [];
+		for (index = 0; index < this.length; index++) {
+			if (index in this) {
+				that.push({ item: this[index], index: index });
+			}
+		}
 		origSort.call(that, function(a, b) {
+			if (b.item === undefined) return -1;
+			if (a.item === undefined) return 1;
 			var compareResult = compareFn.call(undefined, a.item, b.item);
-			return compareResult === 0 ? a.index - b.index : compareResult;
+			return (compareResult === 0 || Number.isNaN(compareResult)) ? a.index - b.index : compareResult;
 		});
 		// update the original object (`this`) with the new position for the items
 		// which were moved.
-		for (var a in that) {
-			if (Object.prototype.hasOwnProperty.call(that, a)) {
-				if (that[a].item !== this[a]) {
-					this[a] = that[a].item;
-				}
+		index = 0;
+		while (index < that.length) {
+			if (that[index]) {
+				this[index] = that[index].item;
 			}
+			index++;
+		}
+		while (index < this.length) {
+			delete this[index++];
 		}
 	}
 

--- a/polyfills/Array/prototype/sort/tests.js
+++ b/polyfills/Array/prototype/sort/tests.js
@@ -28,6 +28,37 @@ it("sorts", function () {
 	);
 });
 
+it("sorts sparse arrays", function () {
+	proclaim.deepStrictEqual(
+		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, , 3].sort(function (a, b) {
+			return a - b;
+		}),
+		// eslint-disable-next-line no-sparse-arrays
+		[3, 4, 5, 6, , ]
+	);
+});
+
+it("sorts arrays with undefined", function () {
+	proclaim.deepStrictEqual(
+		[6, 4, 5, undefined, 3].sort(function (a, b) {
+			return a - b;
+		}),
+		[3, 4, 5, 6, undefined]
+	);
+});
+
+it("sorts arrays with comparefn that returns invalid results", function () {
+	proclaim.deepStrictEqual(
+		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, , 3].sort(function () {
+			return 'x';
+		}),
+		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, 3, , ]
+	);
+});
+
 it("has a stable sort", function () {
 	var obj = {length:3, 0:2, 1:1,2:3};
 	proclaim.deepStrictEqual(


### PR DESCRIPTION
This PR fixes `Array.prototype.sort` so it properly handles sparse arrays, arrays containing `undefined`, and `comparefn` that returns invalid results. This implementation is based on https://github.com/zloirock/core-js/blob/master/packages/core-js/internals/array-sort.js.