### PR TITLE
Removes `Array.prototype.sort` dependency on `Number.isNaN`

### DIFF
--- a/polyfills/Array/prototype/sort/config.toml
+++ b/polyfills/Array/prototype/sort/config.toml
@@ -2,7 +2,6 @@ aliases = [ "es6", "es2015", "modernizr:es6array" ]
 dependencies = [
 	"_ESAbstract.CreateMethodProperty",
 	"_ESAbstract.IsCallable",
-	"Number.isNaN",
 ]
 license = "MIT"
 spec = "http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.sort"

--- a/polyfills/Array/prototype/sort/polyfill.js
+++ b/polyfills/Array/prototype/sort/polyfill.js
@@ -41,10 +41,11 @@ CreateMethodProperty(Array.prototype, "sort", function sort(compareFn) {
 			}
 		}
 		origSort.call(that, function(a, b) {
+			// this implementation is based on https://github.com/zloirock/core-js/blob/master/packages/core-js/modules/es.array.sort.js#L69-L76
 			if (b.item === undefined) return -1;
 			if (a.item === undefined) return 1;
-			var compareResult = compareFn.call(undefined, a.item, b.item);
-			return (compareResult === 0 || Number.isNaN(compareResult)) ? a.index - b.index : compareResult;
+			var compareResult = +(compareFn.call(undefined, a.item, b.item)) || 0;
+			return compareResult === 0 ? a.index - b.index : compareResult;
 		});
 		// update the original object (`this`) with the new position for the items
 		// which were moved.

--- a/polyfills/Array/prototype/sort/tests.js
+++ b/polyfills/Array/prototype/sort/tests.js
@@ -31,6 +31,13 @@ it("sorts", function () {
 it("sorts sparse arrays", function () {
 	proclaim.deepStrictEqual(
 		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, , 3].sort(),
+		// eslint-disable-next-line no-sparse-arrays
+		[3, 4, 5, 6, , ]
+	);
+
+	proclaim.deepStrictEqual(
+		// eslint-disable-next-line no-sparse-arrays
 		[6, 4, 5, , 3].sort(function (a, b) {
 			return a - b;
 		}),
@@ -41,6 +48,11 @@ it("sorts sparse arrays", function () {
 
 it("sorts arrays with undefined", function () {
 	proclaim.deepStrictEqual(
+		[6, 4, 5, undefined, 3].sort(),
+		[3, 4, 5, 6, undefined]
+	);
+
+	proclaim.deepStrictEqual(
 		[6, 4, 5, undefined, 3].sort(function (a, b) {
 			return a - b;
 		}),
@@ -48,11 +60,29 @@ it("sorts arrays with undefined", function () {
 	);
 });
 
-it("sorts arrays with comparefn that returns invalid results", function () {
+it("sorts arrays with comparefn that returns non-number results", function () {
 	proclaim.deepStrictEqual(
 		// eslint-disable-next-line no-sparse-arrays
 		[6, 4, 5, , 3].sort(function () {
 			return 'x';
+		}),
+		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, 3, , ]
+	);
+
+	proclaim.deepStrictEqual(
+		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, , 3].sort(function (a, b) {
+			return (a - b).toString();
+		}),
+		// eslint-disable-next-line no-sparse-arrays
+		[3, 4, 5, 6, , ]
+	);
+
+	proclaim.deepStrictEqual(
+		// eslint-disable-next-line no-sparse-arrays
+		[6, 4, 5, , 3].sort(function () {
+			return '0';
 		}),
 		// eslint-disable-next-line no-sparse-arrays
 		[6, 4, 5, 3, , ]


### PR DESCRIPTION
This PR removes the unnecessary `Number.isNaN` dependency in `Array.prototype.sort`. It also adds more tests to `Array.prototype.sort`.

This is a follow-up to https://github.com/Financial-Times/polyfill-library/pull/1289.